### PR TITLE
Remove redundant/buggy null check

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -174,13 +174,9 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
         @Override
         public void onEvent(Event event, long sequence, boolean endOfBatch) throws Exception {
             DataEndpoint endpoint = getDataEndpoint(true);
-            if (endpoint != null) {
-                endpoint.collectAndSend(event);
-                if (endOfBatch) {
-                    flushAllDataEndpoints();
-                }
-            } else {
-                log.info("Dropping events due to shutdown");
+            endpoint.collectAndSend(event);
+            if (endOfBatch) {
+                flushAllDataEndpoints();
             }
         }
     }


### PR DESCRIPTION
Attempt on fixing the failing test case: `testShutdownDataPublisher()` in `org.wso2.carbon.databridge.agent.test.thrift.OneEndPointDPThriftTest`.
