### PR TITLE
When the websocket adapter client is disconnected, print a log&drop m…

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.websocket.local/src/main/java/org/wso2/carbon/event/output/adapter/websocket/local/WebsocketLocalEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.websocket.local/src/main/java/org/wso2/carbon/event/output/adapter/websocket/local/WebsocketLocalEventAdapter.java
@@ -39,12 +39,14 @@ public final class WebsocketLocalEventAdapter implements OutputEventAdapter {
     private OutputEventAdapterConfiguration eventAdapterConfiguration;
     private Map<String, String> globalProperties;
     private static ThreadPoolExecutor executorService;
+    private boolean doLogDroppedMessage;
 
     private int tenantId;
 
     public WebsocketLocalEventAdapter(OutputEventAdapterConfiguration eventAdapterConfiguration, Map<String, String> globalProperties) {
         this.eventAdapterConfiguration = eventAdapterConfiguration;
         this.globalProperties = globalProperties;
+        this.doLogDroppedMessage = true;
     }
 
 
@@ -153,6 +155,7 @@ public final class WebsocketLocalEventAdapter implements OutputEventAdapter {
             WebsocketLocalOutputCallbackRegisterServiceImpl websocketLocalOutputCallbackRegisterServiceImpl = WebsocketLocalEventAdaptorServiceInternalValueHolder.getWebsocketLocalOutputCallbackRegisterServiceImpl();
             CopyOnWriteArrayList<Session> sessions = websocketLocalOutputCallbackRegisterServiceImpl.getSessions(tenantId, eventAdapterConfiguration.getName());
             if (sessions != null) {
+                doLogDroppedMessage = true;
                 for (Session session : sessions) {
                     synchronized (session) {
                         try {
@@ -162,8 +165,9 @@ public final class WebsocketLocalEventAdapter implements OutputEventAdapter {
                         }
                     }
                 }
-            } else {
+            } else if(doLogDroppedMessage) {
                 EventAdapterUtil.logAndDrop(eventAdapterConfiguration.getName(), message, "Cannot send as session not available", log, tenantId);
+                doLogDroppedMessage = false;
             }
 
         }

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.websocket/src/main/java/org/wso2/carbon/event/output/adapter/websocket/WebsocketEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.websocket/src/main/java/org/wso2/carbon/event/output/adapter/websocket/WebsocketEventAdapter.java
@@ -46,6 +46,7 @@ public final class WebsocketEventAdapter implements OutputEventAdapter {
     private static final Log log = LogFactory.getLog(WebsocketEventAdapter.class);
     private OutputEventAdapterConfiguration eventAdapterConfiguration;
     private Map<String, String> globalProperties;
+    private boolean doLogDroppedMessage;
 
     private Session session;
     private String socketServerUrl;
@@ -55,6 +56,7 @@ public final class WebsocketEventAdapter implements OutputEventAdapter {
     public WebsocketEventAdapter(OutputEventAdapterConfiguration eventAdapterConfiguration, Map<String, String> globalProperties) {
         this.eventAdapterConfiguration = eventAdapterConfiguration;
         this.globalProperties = globalProperties;
+        this.doLogDroppedMessage = true;
     }
 
 
@@ -193,6 +195,7 @@ public final class WebsocketEventAdapter implements OutputEventAdapter {
         @Override
         public void run() {
             if (session != null) {
+                doLogDroppedMessage = true;
                 synchronized (session) {
                     try {
                         session.getBasicRemote().sendText(message);
@@ -200,8 +203,9 @@ public final class WebsocketEventAdapter implements OutputEventAdapter {
                         EventAdapterUtil.logAndDrop(eventAdapterConfiguration.getName(), message, "Cannot send to endpoint", e, log, tenantId);
                     }
                 }
-            } else {
+            } else if(doLogDroppedMessage) {
                 EventAdapterUtil.logAndDrop(eventAdapterConfiguration.getName(), message, "Cannot send as session not available", log, tenantId);
+                doLogDroppedMessage = false;
             }
         }
     }


### PR DESCRIPTION
…essage only once until the client is connected back.
Tharik did this fix for UIAdapter in https://github.com/wso2/carbon-analytics-common/pull/90/.
This is the same fix for websocket adapters.