### PR TITLE
Analytics common OSGI Fixes

### DIFF
--- a/components/event-processor-manager/org.wso2.carbon.event.processor.manager.core/pom.xml
+++ b/components/event-processor-manager/org.wso2.carbon.event.processor.manager.core/pom.xml
@@ -84,7 +84,10 @@
                             !org.wso2.carbon.event.processor.manager.core.internal,
                             org.wso2.carbon.event.processor.manager.core.*
                         </Export-Package>
-                        <Import-Package>org.osgi.framework,*;resolution:=optional</Import-Package>
+                        <Import-Package>
+				org.apache.thrift;version="${libthrift.wso2.imp.pkg.version.range}",
+		        	org.osgi.framework,*;resolution:=optional
+			</Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
When multiple versions of thrift is available, analytics-common component get bound to the latest version, creating issues. Ideally it should be within the specified range in order for the bundle to work properly.