### PR TITLE
Refactoring folder structure of execution-manger to template-manager

### DIFF
--- a/components/execution-manager/org.wso2.carbon.event.execution.manager.core/src/main/java/org/wso2/carbon/event/execution/manager/core/internal/util/ExecutionManagerConstants.java
+++ b/components/execution-manager/org.wso2.carbon.event.execution.manager.core/src/main/java/org/wso2/carbon/event/execution/manager/core/internal/util/ExecutionManagerConstants.java
@@ -27,7 +27,7 @@ public class ExecutionManagerConstants {
 
     // path canged for both cep/spark.
     public static final String TEMPLATE_DOMAIN_PATH = CarbonUtils.getCarbonConfigDirPath()
-            + File.separator + "execution-manager" + File.separator + "domain-template";
+            + File.separator + "template-manager" + File.separator + "domain-template";
 
     public static final String TEMPLATE_CONFIG_PATH = RegistryConstants.PATH_SEPARATOR + "repository"
             + RegistryConstants.PATH_SEPARATOR + "components" + RegistryConstants.PATH_SEPARATOR

--- a/components/gadget-template-deployer/org.wso2.carbon.gadget.template.deployer/src/main/java/org/wso2/carbon/gadget/template/deployer/internal/GadgetTemplateDeployerConstants.java
+++ b/components/gadget-template-deployer/org.wso2.carbon.gadget.template.deployer/src/main/java/org/wso2/carbon/gadget/template/deployer/internal/GadgetTemplateDeployerConstants.java
@@ -31,7 +31,7 @@ public class GadgetTemplateDeployerConstants {
 
     public static final String PROPERTY_TAG = "property";
 
-    public static final String EXECUTION_MANAGER = "execution-manager";
+    public static final String EXECUTION_MANAGER = "template-manager";
 
     public static final String GADGET_TEMPLATES = "gadget-templates";
 

--- a/features/dashboard-template-deployer/org.wso2.carbon.dashboard.template.deployer.server.feature/src/main/resources/p2.inf
+++ b/features/dashboard-template-deployer/org.wso2.carbon.dashboard.template.deployer.server.feature/src/main/resources/p2.inf
@@ -1,4 +1,4 @@
 instructions.configure = \
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/);\
-org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/execution-manager/);\
-org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/execution-manager/domain-template/);
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/template-manager/);\
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/template-manager/domain-template/);

--- a/features/gadget-template-deployer/org.wso2.carbon.gadget.template.deployer.server.feature/src/main/resources/p2.inf
+++ b/features/gadget-template-deployer/org.wso2.carbon.gadget.template.deployer.server.feature/src/main/resources/p2.inf
@@ -1,5 +1,5 @@
 instructions.configure = \
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/);\
-org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/execution-manager/);\
-org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/execution-manager/domain-template/);\
-org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/execution-manager/gadget-templates/);\
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/template-manager/);\
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/template-manager/domain-template/);\
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../conf/template-manager/gadget-templates/);\


### PR DESCRIPTION
This is due to commit d2504273e7eab0354fef73740175aa85bba7c65b which changed the display name of execution manger to template manager