### PR TITLE
Changing full error log into debug level

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointConnectionWorker.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointConnectionWorker.java
@@ -43,7 +43,8 @@ public class DataEndpointConnectionWorker implements Runnable {
                 connect();
                 dataEndpoint.activate();
             } catch (DataEndpointAuthenticationException e) {
-                log.error("Error while trying to connect to the endpoint. " + e.getErrorMessage(), e);
+                log.error("Error while trying to connect to the endpoint. " + e.getErrorMessage());
+                log.debug(e);
                 dataEndpoint.deactivate();
             }
         } else {
@@ -96,7 +97,7 @@ public class DataEndpointConnectionWorker implements Runnable {
                             dataEndpointConfiguration.getPassword());
             dataEndpointConfiguration.setSessionId(sessionId);
         } catch (Throwable e) {
-            log.error(e.getMessage(), e);
+            log.debug(e.getMessage(), e);
             throw new DataEndpointAuthenticationException("Cannot borrow client for " + dataEndpointConfiguration.getAuthURL(), e);
         } finally {
             try {


### PR DESCRIPTION
Remove printing lengthy error when re connection fails and just print 2 lines of log at info-level.

```
[2016-06-27 23:14:52,326]  INFO - DataEndpointGroup No receiver is reachable at reconnection, will try to reconnect every 30 sec
[2016-06-27 23:14:52,338] ERROR - DataEndpointConnectionWorker Error while trying to connect to the endpoint. Cannot borrow client for ssl://localhost:7712


[2016-06-27 23:15:22,326]  INFO - DataEndpointGroup No receiver is reachable at reconnection, will try to reconnect every 30 sec
[2016-06-27 23:15:22,339] ERROR - DataEndpointConnectionWorker Error while trying to connect to the endpoint. Cannot borrow client for ssl://localhost:7712
```

Full log is visible at debug-level.
