### PR TITLE
Add test cases for template-manager component

### DIFF
--- a/components/template-manager/org.wso2.carbon.event.template.manager.admin/pom.xml
+++ b/components/template-manager/org.wso2.carbon.event.template.manager.admin/pom.xml
@@ -47,6 +47,21 @@
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.event.template.manager.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/template-manager/org.wso2.carbon.event.template.manager.admin/src/test/java/org/wso2/carbon/event/template/manager/admin/TemplateManagerAdminServiceTest.java
+++ b/components/template-manager/org.wso2.carbon.event.template.manager.admin/src/test/java/org/wso2/carbon/event/template/manager/admin/TemplateManagerAdminServiceTest.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.event.template.manager.admin;
+
+import org.apache.axis2.AxisFault;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.event.template.manager.admin.dto.configuration.ConfigurationParameterDTO;
+import org.wso2.carbon.event.template.manager.admin.dto.configuration.ScenarioConfigurationDTO;
+import org.wso2.carbon.event.template.manager.admin.dto.configuration.ScenarioConfigurationInfoDTO;
+import org.wso2.carbon.event.template.manager.admin.dto.configuration.StreamMappingDTO;
+import org.wso2.carbon.event.template.manager.admin.dto.domain.DomainInfoDTO;
+import org.wso2.carbon.event.template.manager.admin.dto.domain.DomainParameterDTO;
+import org.wso2.carbon.event.template.manager.admin.dto.domain.ScenarioInfoDTO;
+import org.wso2.carbon.event.template.manager.admin.internal.ds.TemplateManagerAdminServiceValueHolder;
+import org.wso2.carbon.event.template.manager.core.TemplateManagerService;
+import org.wso2.carbon.event.template.manager.core.exception.TemplateManagerException;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.AttributeMapping;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.AttributeMappings;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.ScenarioConfiguration;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.StreamMapping;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.StreamMappings;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Domain;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Parameter;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Parameters;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Scenario;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Scenarios;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+public class TemplateManagerAdminServiceTest {
+
+    @Test
+    public void testGetDomainInfo() throws Exception {
+        Parameter parameter = new Parameter();
+        parameter.setName("parameter-name");
+        parameter.setType("parameter-type");
+        parameter.setDefaultValue("parameter-default-value");
+        parameter.setDescription("parameter-description");
+        parameter.setDisplayName("parameter-display-name");
+        parameter.setOptions("parameter-options");
+        Parameters parameters = new Parameters();
+        parameters.setParameter(Collections.singletonList(parameter));
+        Scenario scenario = new Scenario();
+        scenario.setType("scenario-type");
+        scenario.setDescription("scenario-description");
+        scenario.setParameters(parameters);
+        Scenarios scenarios = new Scenarios();
+        scenarios.setScenario(Collections.singletonList(scenario));
+        final Domain domain = new Domain();
+        domain.setName("domain-name");
+        domain.setDescription("domain-description");
+        domain.setScenarios(scenarios);
+
+        TemplateManagerService templateManagerService = mock(TemplateManagerService.class);
+        when(templateManagerService.getDomain(anyString())).thenReturn(domain);
+        TemplateManagerAdminServiceValueHolder.setTemplateManagerService(templateManagerService);
+
+        DomainInfoDTO domainInfo = new TemplateManagerAdminService().getDomainInfo("domain-name");
+
+        Assert.assertEquals("Incorrect name", domain.getName(), domainInfo.getName());
+        Assert.assertEquals("Incorrect description", domain.getDescription(), domainInfo.getDescription());
+        Assert.assertEquals("Incorrect scenarios", domain.getScenarios().getScenario().size(),
+                            domainInfo.getScenarioInfoDTOs().length);
+
+        ScenarioInfoDTO scenarioInfoDTO = domainInfo.getScenarioInfoDTOs()[0];
+        Assert.assertEquals("Incorrect scenario type", scenario.getType(), scenarioInfoDTO.getType());
+        Assert.assertEquals("Incorrect scenario description", scenario.getDescription(),
+                            scenarioInfoDTO.getDescription());
+        Assert.assertEquals("Incorrect scenario parameters", scenario.getParameters().getParameter().size(),
+                            scenarioInfoDTO.getDomainParameterDTOs().length);
+
+        DomainParameterDTO domainParameterDTO = scenarioInfoDTO.getDomainParameterDTOs()[0];
+        Assert.assertEquals("Incorrect parameter name", parameter.getName(), domainParameterDTO.getName());
+        Assert.assertEquals("Incorrect parameter type", parameter.getType(), domainParameterDTO.getType());
+        Assert.assertEquals("Incorrect parameter default value", parameter.getDefaultValue(),
+                            domainParameterDTO.getDefaultValue());
+        Assert.assertEquals("Incorrect parameter description", parameter.getDescription(),
+                            domainParameterDTO.getDescription());
+        Assert.assertEquals("Incorrect parameter display name", parameter.getDisplayName(),
+                            domainParameterDTO.getDisplayName());
+        Assert.assertEquals("Incorrect parameter options", parameter.getOptions(), domainParameterDTO.getOptions());
+    }
+
+    @Test(expected = AxisFault.class)
+    public void testGetDomainInfoThrowsException() throws Exception {
+        TemplateManagerService templateManagerService = mock(TemplateManagerService.class);
+        when(templateManagerService.getDomain(anyString())).thenThrow(new RuntimeException("some exception"));
+        TemplateManagerAdminServiceValueHolder.setTemplateManagerService(templateManagerService);
+
+        new TemplateManagerAdminService().getDomainInfo(null);
+    }
+
+    @Test
+    public void testGetAllDomainInfos() throws Exception {
+        Parameter parameter = new Parameter();
+        parameter.setName("parameter-name");
+        parameter.setType("parameter-type");
+        parameter.setDefaultValue("parameter-default-value");
+        parameter.setDescription("parameter-description");
+        parameter.setDisplayName("parameter-display-name");
+        parameter.setOptions("parameter-options");
+        Parameters parameters = new Parameters();
+        parameters.setParameter(Collections.singletonList(parameter));
+        Scenario scenario = new Scenario();
+        scenario.setType("scenario-type");
+        scenario.setDescription("scenario-description");
+        scenario.setParameters(parameters);
+        Scenarios scenarios = new Scenarios();
+        scenarios.setScenario(Collections.singletonList(scenario));
+        Domain domain = new Domain();
+        domain.setName("domain-name");
+        domain.setDescription("domain-description");
+        domain.setScenarios(scenarios);
+        final Set<Domain> domains = Collections.singleton(domain);
+
+        TemplateManagerService templateManagerService = mock(TemplateManagerService.class);
+        when(templateManagerService.getAllDomains()).thenReturn(domains);
+        TemplateManagerAdminServiceValueHolder.setTemplateManagerService(templateManagerService);
+
+        DomainInfoDTO[] domainInfos = new TemplateManagerAdminService().getAllDomainInfos();
+        Assert.assertEquals("Incorrect number of domains", domains.size(), domainInfos.length);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void testGetAllDomainInfosThrowsException() throws Exception {
+        TemplateManagerService templateManagerService = mock(TemplateManagerService.class);
+        when(templateManagerService.getAllDomains()).thenThrow(new RuntimeException("some exception"));
+        TemplateManagerAdminServiceValueHolder.setTemplateManagerService(templateManagerService);
+
+        new TemplateManagerAdminService().getAllDomainInfos();
+    }
+
+    @Test
+    public void testGetConfiguration() throws Exception {
+        AttributeMapping attributeMapping = new AttributeMapping();
+        attributeMapping.setFrom("attributeMapping-from");
+        attributeMapping.setTo("attributeMapping-to");
+        AttributeMappings attributeMappings = new AttributeMappings();
+        attributeMappings.setAttributeMapping(Collections.singletonList(attributeMapping));
+        StreamMapping streamMapping = new StreamMapping();
+        streamMapping.setFrom("streamMapping-from");
+        streamMapping.setTo("streamMapping-to");
+        streamMapping.setAttributeMappings(attributeMappings);
+        StreamMappings streamMappings = new StreamMappings();
+        streamMappings.setStreamMapping(Collections.singletonList(streamMapping));
+        final ScenarioConfiguration configuration = new ScenarioConfiguration();
+        configuration.setName("configuration-name");
+        configuration.setScenario("configuration-scenario");
+        configuration.setDescription("configuration-description");
+        configuration.setDomain("configuration-domain");
+        configuration.setParameterMap(Collections.singletonMap("parameter-key", "parameter-value"));
+        configuration.setStreamMappings(streamMappings);
+
+        TemplateManagerService templateManagerService = mock(TemplateManagerService.class);
+        when(templateManagerService.getConfiguration(anyString(), anyString())).thenReturn(configuration);
+        TemplateManagerAdminServiceValueHolder.setTemplateManagerService(templateManagerService);
+
+        ScenarioConfigurationDTO configurationDTO = new TemplateManagerAdminService().getConfiguration("domain-name",
+                                                                                                       "configuration-name");
+        Assert.assertEquals("Incorrect name", configuration.getName(), configurationDTO.getName());
+        Assert.assertEquals("Incorrect type", configuration.getScenario(), configurationDTO.getType());
+        Assert.assertEquals("Incorrect description", configuration.getDescription(), configurationDTO.getDescription());
+        Assert.assertEquals("Incorrect domain", configuration.getDomain(), configurationDTO.getDomain());
+        Assert.assertEquals("Incorrect parameters", configuration.getParameterMap().size(),
+                            configurationDTO.getConfigurationParameterDTOs().length);
+        Assert.assertEquals("Incorrect stream mappings", configuration.getStreamMappings().getStreamMapping().size(),
+                            configurationDTO.getStreamMappingDTOs().length);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void testGetConfigurationThrowsException() throws Exception {
+        TemplateManagerService templateManagerService = mock(TemplateManagerService.class);
+        when(templateManagerService.getConfiguration(anyString(), anyString()))
+                .thenThrow(new TemplateManagerException("some exception"));
+        TemplateManagerAdminServiceValueHolder.setTemplateManagerService(templateManagerService);
+
+        new TemplateManagerAdminService().getConfiguration(null, null);
+    }
+
+    @Test
+    public void testGetConfigurationInfos() throws Exception {
+        AttributeMapping attributeMapping = new AttributeMapping();
+        attributeMapping.setFrom("attributeMapping-from");
+        attributeMapping.setTo("attributeMapping-to");
+        AttributeMappings attributeMappings = new AttributeMappings();
+        attributeMappings.setAttributeMapping(Collections.singletonList(attributeMapping));
+        StreamMapping streamMapping = new StreamMapping();
+        streamMapping.setFrom("streamMapping-from");
+        streamMapping.setTo("streamMapping-to");
+        streamMapping.setAttributeMappings(attributeMappings);
+        StreamMappings streamMappings = new StreamMappings();
+        streamMappings.setStreamMapping(Collections.singletonList(streamMapping));
+        ScenarioConfiguration configuration = new ScenarioConfiguration();
+        configuration.setName("configuration-name");
+        configuration.setScenario("configuration-scenario");
+        configuration.setDescription("configuration-description");
+        configuration.setDomain("configuration-domain");
+        configuration.setParameterMap(Collections.singletonMap("parameter-key", "parameter-value"));
+        configuration.setStreamMappings(streamMappings);
+        List<ScenarioConfiguration> configurations = Collections.singletonList(configuration);
+
+        TemplateManagerService templateManagerService = mock(TemplateManagerService.class);
+        when(templateManagerService.getConfigurations(anyString())).thenReturn(configurations);
+        TemplateManagerAdminServiceValueHolder.setTemplateManagerService(templateManagerService);
+
+        ScenarioConfigurationInfoDTO[] configurationInfos = new TemplateManagerAdminService()
+                .getConfigurationInfos("domain-name");
+        Assert.assertEquals("Incorrect number of configurations", configurations.size(), configurationInfos.length);
+    }
+
+    @Test(expected = AxisFault.class)
+    public void testGetConfigurationInfosThrowsException() throws Exception {
+        TemplateManagerService templateManagerService = mock(TemplateManagerService.class);
+        when(templateManagerService.getConfigurations(anyString()))
+                .thenThrow(new TemplateManagerException("some exception"));
+        TemplateManagerAdminServiceValueHolder.setTemplateManagerService(templateManagerService);
+
+        new TemplateManagerAdminService().getConfigurationInfos(null);
+    }
+
+    @Test
+    public void testDeleteConfiguration() throws Exception {
+        TemplateManagerService templateManagerService = mock(TemplateManagerService.class);
+        TemplateManagerAdminServiceValueHolder.setTemplateManagerService(templateManagerService);
+        Assert.assertTrue("Returned false", new TemplateManagerAdminService().deleteConfiguration(null, null));
+    }
+
+    @Test
+    public void testSaveConfiguration() throws Exception {
+        TemplateManagerService templateManagerService = mock(TemplateManagerService.class);
+        when(templateManagerService.saveConfiguration(any(ScenarioConfiguration.class))).thenReturn(null);
+        TemplateManagerAdminServiceValueHolder.setTemplateManagerService(templateManagerService);
+
+        TemplateManagerAdminService templateManagerAdminService = new TemplateManagerAdminService();
+
+        ScenarioConfigurationDTO configuration = new ScenarioConfigurationDTO();
+        ConfigurationParameterDTO configurationParameterDTO = new ConfigurationParameterDTO();
+        configuration.setConfigurationParameterDTOs(new ConfigurationParameterDTO[]{configurationParameterDTO});
+
+        Assert.assertNull("Return value should be null when Template Manager Service returns null",
+                          templateManagerAdminService.saveConfiguration(configuration));
+
+        final List<String> streamIds = Collections.singletonList("stream-id");
+        when(templateManagerService.saveConfiguration(any(ScenarioConfiguration.class))).thenReturn(streamIds);
+        Assert.assertEquals("Incorrect number of stream IDs", streamIds.size(),
+                            templateManagerAdminService.saveConfiguration(configuration).length);
+    }
+
+    @Test
+    public void testEditConfiguration() throws Exception {
+        TemplateManagerService templateManagerService = mock(TemplateManagerService.class);
+        when(templateManagerService.editConfiguration(any(ScenarioConfiguration.class))).thenReturn(null);
+        TemplateManagerAdminServiceValueHolder.setTemplateManagerService(templateManagerService);
+
+        TemplateManagerAdminService templateManagerAdminService = new TemplateManagerAdminService();
+
+        Assert.assertNull("Return value should be null when Template Manager Service returns null",
+                          templateManagerAdminService.editConfiguration(null));
+
+        final List<String> streamIds = Collections.singletonList("stream-id");
+        when(templateManagerService.editConfiguration(any(ScenarioConfiguration.class))).thenReturn(streamIds);
+        Assert.assertEquals("Incorrect number of stream IDs", streamIds.size(),
+                            templateManagerAdminService.editConfiguration(new ScenarioConfigurationDTO()).length);
+    }
+
+    @Test
+    public void testSaveStreamMapping() throws Exception {
+        TemplateManagerService templateManagerService = mock(TemplateManagerService.class);
+        TemplateManagerAdminServiceValueHolder.setTemplateManagerService(templateManagerService);
+
+        boolean saved = new TemplateManagerAdminService().saveStreamMapping(new StreamMappingDTO[0], null, null);
+        Assert.assertTrue("Stream mappings didn't saved", saved);
+    }
+}

--- a/components/template-manager/org.wso2.carbon.event.template.manager.admin/src/test/java/org/wso2/carbon/event/template/manager/admin/internal/util/ConfigurationMapperTest.java
+++ b/components/template-manager/org.wso2.carbon.event.template.manager.admin/src/test/java/org/wso2/carbon/event/template/manager/admin/internal/util/ConfigurationMapperTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.event.template.manager.admin.internal.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.event.template.manager.admin.dto.configuration.AttributeMappingDTO;
+import org.wso2.carbon.event.template.manager.admin.dto.configuration.ScenarioConfigurationDTO;
+import org.wso2.carbon.event.template.manager.admin.dto.configuration.StreamMappingDTO;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.ScenarioConfiguration;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.StreamMapping;
+
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(PowerMockRunner.class)
+public class ConfigurationMapperTest {
+
+    @Test
+    public void testMapStreamMapping() {
+        AttributeMappingDTO attributeMappingDTO = new AttributeMappingDTO();
+        attributeMappingDTO.setAttributeType("attribute-type");
+        attributeMappingDTO.setFromAttribute("attribute-from");
+        attributeMappingDTO.setToAttribute("attribute-to");
+        StreamMappingDTO streamMappingDTO = new StreamMappingDTO();
+        streamMappingDTO.setFromStream("from-stream");
+        streamMappingDTO.setToStream("to-stream");
+        streamMappingDTO.setAttributeMappingDTOs(new AttributeMappingDTO[]{attributeMappingDTO});
+        StreamMappingDTO[] streamMappingDTOs = new StreamMappingDTO[]{streamMappingDTO};
+
+        List<StreamMapping> streamMappings = ConfigurationMapper.mapStreamMapping(streamMappingDTOs);
+
+        Assert.assertEquals("Incorrect number of stream mappings", streamMappingDTOs.length, streamMappings.size());
+    }
+
+    @Test
+    public void testMapConfigurations() {
+        List<ScenarioConfiguration> configurations = Collections.singletonList(new ScenarioConfiguration());
+        ScenarioConfigurationDTO[] configurationDTOS = ConfigurationMapper.mapConfigurations(configurations);
+        Assert.assertEquals("Incorrect number of configuration DTOs", configurations.size(), configurationDTOS.length);
+    }
+}

--- a/components/template-manager/org.wso2.carbon.event.template.manager.core/pom.xml
+++ b/components/template-manager/org.wso2.carbon.event.template.manager.core/pom.xml
@@ -51,6 +51,21 @@
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.event.stream.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
       <build>

--- a/components/template-manager/org.wso2.carbon.event.template.manager.core/src/test/java/org/wso2/carbon/event/template/manager/core/internal/CarbonTemplateManagerServiceTest.java
+++ b/components/template-manager/org.wso2.carbon.event.template.manager.core/src/test/java/org/wso2/carbon/event/template/manager/core/internal/CarbonTemplateManagerServiceTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.event.template.manager.core.internal;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.event.template.manager.core.TemplateDeployer;
+import org.wso2.carbon.event.template.manager.core.exception.TemplateManagerException;
+import org.wso2.carbon.event.template.manager.core.internal.ds.TemplateManagerValueHolder;
+import org.wso2.carbon.event.template.manager.core.internal.util.TemplateManagerConstants;
+import org.wso2.carbon.event.template.manager.core.internal.util.TemplateManagerHelper;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.ScenarioConfiguration;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.StreamMapping;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Domain;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Scenario;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Scenarios;
+import org.wso2.carbon.registry.core.RegistryConstants;
+import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.registry.core.session.UserRegistry;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.script.ScriptEngine;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({TemplateManagerHelper.class})
+public class CarbonTemplateManagerServiceTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+    @Captor
+    private ArgumentCaptor<Domain> domainArgument;
+    @Captor
+    private ArgumentCaptor<String> stringArgument;
+
+    @BeforeClass
+    public static void init() {
+        System.setProperty("carbon.home", "");
+    }
+
+    @Before
+    public void initMocks() {
+        MockitoAnnotations.initMocks(this);
+        mockStatic(TemplateManagerHelper.class);
+    }
+
+    @Test
+    public void testSaveConfigurationWhenResourceExists() throws Exception {
+        UserRegistry registry = mock(UserRegistry.class);
+        when(registry.resourceExists(anyString())).thenReturn(true);
+        RegistryService registryService = mock(RegistryService.class);
+        when(registryService.getConfigSystemRegistry(anyInt())).thenReturn(registry);
+        TemplateManagerValueHolder.setRegistryService(registryService);
+
+        thrown.expect(TemplateManagerException.class);
+        createCarbonTemplateManagerService().saveConfiguration(new ScenarioConfiguration());
+    }
+
+    @Test
+    public void testSaveConfiguration() throws Exception {
+        UserRegistry registry = mock(UserRegistry.class);
+        when(registry.resourceExists(anyString())).thenReturn(false);
+        RegistryService registryService = mock(RegistryService.class);
+        when(registryService.getConfigSystemRegistry(anyInt())).thenReturn(registry);
+        TemplateManagerValueHolder.setRegistryService(registryService);
+
+        when(TemplateManagerHelper.getStreamIDsToBeMapped(any(ScenarioConfiguration.class), any(Domain.class),
+                                                          any(ScriptEngine.class))).thenCallRealMethod();
+
+        CarbonTemplateManagerService carbonTemplateManagerService = createCarbonTemplateManagerService();
+        Domain domain = carbonTemplateManagerService.getDomain("test-domain");
+        ScenarioConfiguration configuration = new ScenarioConfiguration();
+        configuration.setDomain(domain.getName());
+
+        Assert.assertNull("Return value should be null", carbonTemplateManagerService.saveConfiguration(configuration));
+
+        verifyStatic();
+        TemplateManagerHelper.deployArtifacts(any(ScenarioConfiguration.class), domainArgument.capture(),
+                                              any(ScriptEngine.class));
+        Assert.assertEquals("Incorrect domain was passed to deployArtifacts method", domain, domainArgument.getValue());
+
+        verifyStatic();
+        TemplateManagerHelper.getStreamIDsToBeMapped(any(ScenarioConfiguration.class), domainArgument.capture(),
+                                                     any(ScriptEngine.class));
+        Assert.assertEquals("Incorrect domain was passed to getStreamIDsToBeMapped method", domain,
+                            domainArgument.getValue());
+    }
+
+    @Test
+    public void testSaveStreamMapping() throws Exception {
+        final String scenarioConfigName = "scenario-config-name";
+        final String domainName = "domain-name";
+        final List<StreamMapping> streamMappingList = Collections.emptyList();
+        when(TemplateManagerHelper.getConfiguration(anyString())).thenReturn(new ScenarioConfiguration());
+        when(TemplateManagerHelper.getStreamMappingPlanId(domainName, scenarioConfigName)).thenReturn("plan-id");
+        when(TemplateManagerHelper.generateExecutionPlan(streamMappingList, "plan-id")).thenReturn("execution-plan");
+
+        try {
+            createCarbonTemplateManagerService().saveStreamMapping(streamMappingList, scenarioConfigName, domainName);
+            Assert.fail("Artifacts deployed without a template deployer for type '" +
+                        TemplateManagerConstants.DEPLOYER_TYPE_REALTIME + "'");
+        } catch (TemplateManagerException e) {
+            // fine
+        }
+
+        TemplateDeployer templateDeployer = mock(TemplateDeployer.class);
+        ConcurrentHashMap<String, TemplateDeployer> deployers = TemplateManagerValueHolder.getTemplateDeployers();
+        deployers.put(TemplateManagerConstants.DEPLOYER_TYPE_REALTIME, templateDeployer);
+        createCarbonTemplateManagerService().saveStreamMapping(streamMappingList, scenarioConfigName, domainName);
+    }
+
+    @Test
+    public void testGetDomain() throws Exception {
+        final String domainName = "test-domain";
+        Domain domain = createCarbonTemplateManagerService().getDomain(domainName);
+        Assert.assertNotNull("domain cannot be null", domain);
+        Assert.assertEquals("incorrect domain name", domainName, domain.getName());
+    }
+
+    @Test
+    public void testGetConfiguration() throws Exception {
+        final String domainName = "domain-name";
+        final String configName = "config-name";
+        final String registryPath = TemplateManagerConstants.TEMPLATE_CONFIG_PATH + "/" + domainName + "/" +
+                                    configName + TemplateManagerConstants.CONFIG_FILE_EXTENSION;
+        createCarbonTemplateManagerService().getConfiguration(domainName, configName);
+
+        verifyStatic();
+        TemplateManagerHelper.getConfiguration(stringArgument.capture());
+        Assert.assertEquals("Incorrect registry path", registryPath, stringArgument.getValue());
+    }
+
+    @Test
+    public void testDeleteConfiguration() throws Exception {
+        ScenarioConfiguration configuration = new ScenarioConfiguration();
+        when(TemplateManagerHelper.getConfiguration(anyString())).thenReturn(configuration);
+
+        UserRegistry registry = mock(UserRegistry.class);
+        RegistryService registryService = mock(RegistryService.class);
+        when(registryService.getConfigSystemRegistry(anyInt())).thenReturn(registry);
+        TemplateManagerValueHolder.setRegistryService(registryService);
+
+        when(TemplateManagerHelper.getTemplatedArtifactId(anyString(), anyString(), anyString(), anyString(), anyInt()))
+                .thenCallRealMethod();
+
+        final String domainName = "test-domain";
+        final String configName = "config-name";
+
+        createCarbonTemplateManagerService().deleteConfiguration(domainName, configName);
+
+        Mockito.verify(registry).delete(stringArgument.capture());
+        Assert.assertEquals("Incorrect registry path for deletion",
+                            TemplateManagerConstants.TEMPLATE_CONFIG_PATH + RegistryConstants.PATH_SEPARATOR +
+                            domainName + RegistryConstants.PATH_SEPARATOR + configName +
+                            TemplateManagerConstants.CONFIG_FILE_EXTENSION,
+                            stringArgument.getValue());
+    }
+
+    private CarbonTemplateManagerService createCarbonTemplateManagerService() throws Exception {
+        Scenarios scenarios = new Scenarios();
+        scenarios.setScenario(Collections.<Scenario>emptyList());
+        Domain domain = new Domain();
+        domain.setName("test-domain");
+        domain.setScenarios(scenarios);
+        Map<String, Domain> domains = Collections.singletonMap(domain.getName(), domain);
+        when(TemplateManagerHelper.loadDomains()).thenReturn(domains);
+        return new CarbonTemplateManagerService();
+    }
+}

--- a/components/template-manager/org.wso2.carbon.event.template.manager.core/src/test/java/org/wso2/carbon/event/template/manager/core/internal/util/TemplateManagerHelperTest.java
+++ b/components/template-manager/org.wso2.carbon.event.template.manager.core/src/test/java/org/wso2/carbon/event/template/manager/core/internal/util/TemplateManagerHelperTest.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.event.template.manager.core.internal.util;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.wso2.carbon.databridge.commons.Attribute;
+import org.wso2.carbon.databridge.commons.StreamDefinition;
+import org.wso2.carbon.event.stream.core.EventStreamService;
+import org.wso2.carbon.event.template.manager.core.TemplateDeployer;
+import org.wso2.carbon.event.template.manager.core.TemplateDeploymentException;
+import org.wso2.carbon.event.template.manager.core.exception.TemplateManagerException;
+import org.wso2.carbon.event.template.manager.core.internal.ds.TemplateManagerValueHolder;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.AttributeMapping;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.AttributeMappings;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.ScenarioConfiguration;
+import org.wso2.carbon.event.template.manager.core.structure.configuration.StreamMapping;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Artifact;
+import org.wso2.carbon.event.template.manager.core.structure.domain.CommonArtifacts;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Domain;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Scenario;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Scenarios;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Script;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Scripts;
+import org.wso2.carbon.event.template.manager.core.structure.domain.StreamMappings;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Template;
+import org.wso2.carbon.event.template.manager.core.structure.domain.Templates;
+import org.wso2.carbon.registry.core.RegistryConstants;
+import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.registry.core.session.UserRegistry;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.script.ScriptEngine;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Test cases for {@link TemplateManagerHelper} class.
+ */
+@RunWith(PowerMockRunner.class)
+public class TemplateManagerHelperTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+    @Captor
+    private ArgumentCaptor<String> stringArgument;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+        System.setProperty("carbon.home", "");
+    }
+
+    @Test
+    public void testLoadDomains() {
+        Assert.assertEquals("Domains should be empty as " + TemplateManagerConstants.TEMPLATE_DOMAIN_PATH +
+                            " directory doesn't exists", 0, TemplateManagerHelper.loadDomains().size());
+    }
+
+    @Test
+    public void testDeployArtifacts() throws Exception {
+        final Domain domain = new Domain();
+        Artifact artifact = new Artifact();
+        artifact.setType("artifact-type");
+        CommonArtifacts commonArtifacts = new CommonArtifacts();
+        commonArtifacts.setArtifact(Collections.singletonList(artifact));
+        domain.setCommonArtifacts(commonArtifacts);
+        Template template = mock(Template.class);
+        when(template.getType()).thenReturn("template-type");
+        when(template.getValue()).thenReturn("template-value");
+        Templates templates = new Templates();
+        templates.setTemplate(Collections.singletonList(template));
+        Scenario scenario = new Scenario();
+        scenario.setType("scenario-type");
+        scenario.setTemplates(templates);
+        Scenarios scenarios = new Scenarios();
+        scenarios.setScenario(Collections.singletonList(scenario));
+        domain.setScenarios(scenarios);
+        final ScenarioConfiguration configuration = new ScenarioConfiguration();
+        configuration.setScenario(scenario.getType());
+        final ScriptEngine scriptEngine = TemplateManagerHelper.createJavaScriptEngine(null);
+
+        try {
+            TemplateManagerHelper.deployArtifacts(configuration, domain, scriptEngine);
+            Assert.fail("Artifacts deployed without a template deployer for type '" + artifact.getType() + "'");
+        } catch (TemplateDeploymentException e) {
+            // fine
+        }
+
+        TemplateDeployer artifactDeployer = mock(TemplateDeployer.class);
+        ConcurrentHashMap<String, TemplateDeployer> deployers = TemplateManagerValueHolder.getTemplateDeployers();
+        deployers.put(artifact.getType(), artifactDeployer);
+        try {
+            TemplateManagerHelper.deployArtifacts(configuration, domain, scriptEngine);
+            Assert.fail("Artifacts deployed without a template deployer for type '" + template.getType() + "'");
+        } catch (TemplateDeploymentException e) {
+            // fine
+        }
+
+        TemplateDeployer templateDeployer = mock(TemplateDeployer.class);
+        deployers.put(template.getType(), templateDeployer);
+        TemplateManagerHelper.deployArtifacts(configuration, domain, scriptEngine);
+    }
+
+    @Test
+    public void testCreateJavaScriptEngine() throws Exception {
+        final Domain domain = new Domain();
+        Script script = new Script();
+        Scripts scripts = new Scripts();
+        scripts.setScript(Collections.singletonList(script));
+        domain.setScripts(scripts);
+
+        script.setSrc("script.js");
+        script.setContent(null);
+        ScriptEngine scriptEngine = TemplateManagerHelper.createJavaScriptEngine(domain);
+        Assert.assertNotNull("JavaScript engine cannot be null", scriptEngine);
+
+        script.setSrc(null);
+        script.setContent("var a = 0;");
+        scriptEngine = TemplateManagerHelper.createJavaScriptEngine(domain);
+        Assert.assertNotNull("JavaScript engine cannot be null", scriptEngine);
+    }
+
+    @Test
+    public void testValidateTemplateDomainConfig() {
+        Domain domain = new Domain();
+
+        try {
+            domain.setName(null);
+            TemplateManagerHelper.validateTemplateDomainConfig(domain);
+            Assert.fail("Domain name cannot be null.");
+        } catch (TemplateManagerException e) {
+            // fine
+        }
+
+        try {
+            domain.setName("");
+            domain.setScenarios(null);
+            TemplateManagerHelper.validateTemplateDomainConfig(domain);
+            Assert.fail("Domain scenarios cannot be null.");
+        } catch (TemplateManagerException e) {
+            // fine
+        }
+
+        try {
+            domain.setName("");
+            Scenarios scenarios = new Scenarios();
+            scenarios.setScenario(Collections.<Scenario>emptyList());
+            domain.setScenarios(scenarios);
+            TemplateManagerHelper.validateTemplateDomainConfig(domain);
+            Assert.fail("Domain scenarios cannot be empty.");
+        } catch (TemplateManagerException e) {
+            // fine
+        }
+    }
+
+    @Test
+    public void testGetStreamIDsToBeMapped() throws Exception {
+        final Domain domain = new Domain();
+        Scenario scenario = new Scenario();
+        scenario.setType("scenario-type");
+        scenario.setStreamMappings(null);
+        Scenarios scenarios = new Scenarios();
+        scenarios.setScenario(Collections.singletonList(scenario));
+        domain.setScenarios(scenarios);
+
+        final ScenarioConfiguration configuration = new ScenarioConfiguration();
+        configuration.setScenario(scenario.getType());
+        configuration.setParameterMap(Collections.singletonMap("key", "value"));
+
+        final ScriptEngine scriptEngine = TemplateManagerHelper.createJavaScriptEngine(null);
+
+        List<String> streamIds = TemplateManagerHelper.getStreamIDsToBeMapped(configuration, domain, scriptEngine);
+        Assert.assertNull("When scenario stream mappings is null, stream IDs should be null", streamIds);
+
+        org.wso2.carbon.event.template.manager.core.structure.domain.StreamMapping
+                streamMapping = new org.wso2.carbon.event.template.manager.core.structure.domain.StreamMapping();
+        streamMapping.setTo("foo");
+        StreamMappings streamMappings = new StreamMappings();
+        streamMappings.setStreamMapping(Collections.singletonList(streamMapping));
+        scenario.setStreamMappings(streamMappings);
+        streamIds = TemplateManagerHelper.getStreamIDsToBeMapped(configuration, domain, scriptEngine);
+        Assert.assertNotNull("When scenario stream mappings is present, stream IDs cannot be null", streamIds);
+    }
+
+    @Test
+    public void testGenerateExecutionPlan() throws Exception {
+        StreamDefinition streamDefinition = mock(StreamDefinition.class);
+        when(streamDefinition.getMetaData()).thenReturn(Collections.<Attribute>emptyList());
+        when(streamDefinition.getCorrelationData()).thenReturn(Collections.<Attribute>emptyList());
+        when(streamDefinition.getPayloadData()).thenReturn(Collections.<Attribute>emptyList());
+        EventStreamService eventStreamService = mock(EventStreamService.class);
+        when(eventStreamService.getStreamDefinition(anyString())).thenReturn(streamDefinition);
+        TemplateManagerValueHolder.setEventStreamService(eventStreamService);
+
+        AttributeMapping attributeMapping = new AttributeMapping();
+        attributeMapping.setFrom("FOO");
+        attributeMapping.setTo("BAR");
+        AttributeMappings attributeMappings = new AttributeMappings();
+        attributeMappings.setAttributeMapping(Collections.singletonList(attributeMapping));
+        StreamMapping streamMapping = new StreamMapping();
+        streamMapping.setFrom("foo");
+        streamMapping.setTo("bar");
+        streamMapping.setAttributeMappings(attributeMappings);
+        final List<StreamMapping> streamMappingList = Collections.singletonList(streamMapping);
+
+        final String planName = "plan-name";
+        final String executionPlan = "@Plan:name('" + planName + "') \n" +
+                                     "\n" +
+                                     "@IMPORT('" + streamMapping.getFrom() + "')\n" +
+                                     "define stream " + streamMapping.getFrom() + "();\n" +
+                                     "\n" +
+                                     "@EXPORT('" + streamMapping.getTo() + "')\n" +
+                                     "define stream " + streamMapping.getTo() + "();\n" +
+                                     "\n" +
+                                     "from " + streamMapping.getFrom() + " \n" +
+                                     "select " + attributeMapping.getFrom() + " as " + attributeMapping.getTo() +
+                                     " \n" +
+                                     "insert into " + streamMapping.getTo() + ";\n" +
+                                     "\n";
+        Assert.assertEquals("Incorrect execution plan", executionPlan,
+                            TemplateManagerHelper.generateExecutionPlan(streamMappingList, planName));
+    }
+
+    @Test
+    public void testDeleteConfigWithoutUndeploy() throws Exception {
+        final String domainName = "test-domainName";
+        final String configName = "test-configName";
+        final String registryPath = TemplateManagerConstants.TEMPLATE_CONFIG_PATH + RegistryConstants.PATH_SEPARATOR +
+                                    domainName + RegistryConstants.PATH_SEPARATOR + configName +
+                                    TemplateManagerConstants.CONFIG_FILE_EXTENSION;
+
+        UserRegistry registry = mock(UserRegistry.class);
+        RegistryService registryService = mock(RegistryService.class);
+        when(registryService.getConfigSystemRegistry(anyInt())).thenReturn(registry);
+        TemplateManagerValueHolder.setRegistryService(registryService);
+
+        TemplateManagerHelper.deleteConfigWithoutUndeploy(domainName, configName);
+        verify(registry).delete(stringArgument.capture());
+        Assert.assertEquals("Incorrect registry path for deletion", registryPath, stringArgument.getValue());
+    }
+
+    @Test
+    public void testGetConfiguration() throws Exception {
+        final String resourcePath = "/path/to/resource";
+
+        UserRegistry registry = mock(UserRegistry.class);
+        when(registry.resourceExists(resourcePath)).thenReturn(false);
+        RegistryService registryService = mock(RegistryService.class);
+        when(registryService.getConfigSystemRegistry(anyInt())).thenReturn(registry);
+        TemplateManagerValueHolder.setRegistryService(registryService);
+
+        ScenarioConfiguration configuration = TemplateManagerHelper.getConfiguration(resourcePath);
+        Assert.assertNull("When resource doesn't exists, scenario configuration must be null", configuration);
+
+        when(registry.get(resourcePath)).thenReturn(null);
+        configuration = TemplateManagerHelper.getConfiguration(resourcePath);
+        Assert.assertNull("When registry.get(path) returns null scenario configuration must be null", configuration);
+    }
+
+    @Test
+    public void testGetTemplatedArtifactId() {
+        final String domainName = "test-domainName";
+        final String scenarioName = "test-scenarioName";
+        final String scenarioConfigName = "test-scenarioConfigName";
+        final String artifactType = "test-artifactType";
+        final int sequenceNumber = 0;
+        final String templateArtifactId = domainName + TemplateManagerConstants.CONFIG_NAME_SEPARATOR + scenarioName +
+                                          TemplateManagerConstants.CONFIG_NAME_SEPARATOR + scenarioConfigName +
+                                          TemplateManagerConstants.CONFIG_NAME_SEPARATOR + artifactType +
+                                          sequenceNumber;
+
+        Assert.assertEquals("Incorrect template artifact ID", templateArtifactId,
+                            TemplateManagerHelper.getTemplatedArtifactId(domainName, scenarioName, scenarioConfigName,
+                                                                         artifactType, sequenceNumber));
+    }
+
+    @Test
+    public void testGetStreamMappingPlanId() {
+        final String domainName = "test-domainName";
+        final String scenarioConfigName = "test-scenarioConfigName";
+        final String streamMappingPlanId =
+                domainName + TemplateManagerConstants.CONFIG_NAME_SEPARATOR + scenarioConfigName +
+                TemplateManagerConstants.CONFIG_NAME_SEPARATOR + TemplateManagerConstants.STREAM_MAPPING_PLAN_SUFFIX;
+
+        Assert.assertEquals("Incorrect stream mapping plan ID", streamMappingPlanId,
+                            TemplateManagerHelper.getStreamMappingPlanId(domainName, scenarioConfigName));
+    }
+
+    @Test
+    public void testGetCommonArtifactId() {
+        final String domainName = "test-domainName";
+        final String artifactType = "test-artifactType";
+        final int sequenceNumber = 0;
+        final String commonArtifactId =
+                domainName + TemplateManagerConstants.CONFIG_NAME_SEPARATOR + artifactType + sequenceNumber;
+
+        Assert.assertEquals("Incorrect stream mapping plan ID", commonArtifactId,
+                            TemplateManagerHelper.getCommonArtifactId(domainName, artifactType, sequenceNumber));
+    }
+}

--- a/components/template-manager/pom.xml
+++ b/components/template-manager/pom.xml
@@ -38,5 +38,12 @@
         <module>org.wso2.carbon.event.template.manager.ui</module>
     </modules>
 
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
- Test coverage for `org.wso2.carbon.event.template.manager.admin` : 85%
- Test coverage for `org.wso2.carbon.event.template.manager.core` : 51%