### PR TITLE
Remove JaCoCo plugin from Execution Manager Aggregator module

### DIFF
--- a/components/template-manager/org.wso2.carbon.event.template.manager.admin/pom.xml
+++ b/components/template-manager/org.wso2.carbon.event.template.manager.admin/pom.xml
@@ -96,6 +96,10 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/components/template-manager/org.wso2.carbon.event.template.manager.core/pom.xml
+++ b/components/template-manager/org.wso2.carbon.event.template.manager.core/pom.xml
@@ -106,6 +106,10 @@
                       </instructions>
                   </configuration>
               </plugin>
+              <plugin>
+                  <groupId>org.jacoco</groupId>
+                  <artifactId>jacoco-maven-plugin</artifactId>
+              </plugin>
           </plugins>
       </build>
 

--- a/components/template-manager/pom.xml
+++ b/components/template-manager/pom.xml
@@ -38,12 +38,5 @@
         <module>org.wso2.carbon.event.template.manager.ui</module>
     </modules>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+
 </project>


### PR DESCRIPTION
This PR removes the JaCoCo Maven plugin from `Execution Manager Aggregator` module and adds it to `Execution Manager Admin` component module & `Execution Manager Core` component module.