### PR TITLE
Fixing build failure by setting default encoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1541,6 +1541,9 @@
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.4</powermock.version>
         <org.jacoco.ant.version>0.7.5.201505241946</org.jacoco.ant.version>
+
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>


### PR DESCRIPTION
## Purpose
>5.1.x build is failing due to test case failures.

## Goals
> Setting the default encoding to UTF-8

## Approach
> Included encoding configurations on POM