### PR TITLE
Forcefully setting encoding to UTF-8 in code level.

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/pom.xml
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/pom.xml
@@ -123,10 +123,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/binary/BinaryEventSender.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/binary/BinaryEventSender.java
@@ -112,7 +112,7 @@ public class BinaryEventSender {
         outputstream.flush();
     }
 
-    private static int getEventSize(Event event) {
+    private static int getEventSize(Event event) throws IOException {
         int eventSize = 4 + event.getStreamId().length() + 8;
         Object[] data = event.getMetaData();
         if (data != null) {

--- a/components/data-bridge/org.wso2.carbon.databridge.commons.binary/src/main/java/org/wso2/carbon/databridge/commons/binary/BinaryMessageConverterUtil.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.commons.binary/src/main/java/org/wso2/carbon/databridge/commons/binary/BinaryMessageConverterUtil.java
@@ -47,9 +47,9 @@ public class BinaryMessageConverterUtil {
         return new String(bytes);
     }
 
-    public static int getSize(Object data) {
+    public static int getSize(Object data) throws IOException {
         if (data instanceof String) {
-            return 4 + ((String) data).getBytes().length;
+            return 4 + ((String) data).getBytes(BinaryMessageConstants.DEFAULT_CHARSET).length;
         } else if (data instanceof Integer) {
             return 4;
         } else if (data instanceof Long) {
@@ -67,7 +67,7 @@ public class BinaryMessageConverterUtil {
 
     public static void assignData(Object data, ByteBuffer eventDataBuffer) throws IOException {
         if (data instanceof String) {
-            eventDataBuffer.putInt(((String) data).getBytes().length);
+            eventDataBuffer.putInt(((String) data).getBytes(BinaryMessageConstants.DEFAULT_CHARSET).length);
             eventDataBuffer.put(((String) data).getBytes(BinaryMessageConstants.DEFAULT_CHARSET));
         } else if (data instanceof Integer) {
             eventDataBuffer.putInt((Integer) data);

--- a/components/data-bridge/org.wso2.carbon.databridge.commons.binary/src/test/java/org/wso2/carbon/databridge/commons/binary/test/BinaryMessageConvertUtilTest.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.commons.binary/src/test/java/org/wso2/carbon/databridge/commons/binary/test/BinaryMessageConvertUtilTest.java
@@ -38,7 +38,7 @@ public class BinaryMessageConvertUtilTest {
     Logger log = Logger.getLogger(BinaryMessageConvertUtilTest.class);
 
     @Test
-    public void testEventBufferSize() {
+    public void testEventBufferSize() throws IOException {
         int stringSize = BinaryMessageConverterUtil.getSize("i♥apim)");
         int intSize = BinaryMessageConverterUtil.getSize(1);
         int longSize = BinaryMessageConverterUtil.getSize(1L);

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/test/java/org.wso2.carbon.databridge.receiver.binary.test/util/BinaryServerUtil.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/test/java/org.wso2.carbon.databridge.receiver.binary.test/util/BinaryServerUtil.java
@@ -48,7 +48,7 @@ import static org.wso2.carbon.databridge.commons.binary.BinaryMessageConverterUt
 public class BinaryServerUtil {
 
     public static final Path testDir = Paths.get("src", "test", "resources");
-    
+
     private static Logger log = Logger.getLogger(BinaryServerUtil.class);
 
     public static byte[] convertEventToByteArray(Event event, String sessionId) throws IOException {
@@ -120,7 +120,7 @@ public class BinaryServerUtil {
         }
     }
 
-    private static int getEventSize(Event event) {
+    private static int getEventSize(Event event) throws IOException {
         int eventSize = 4 + event.getStreamId().length() + 8;
         Object[] data = event.getMetaData();
         if (data != null) {

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.mqtt/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.mqtt/pom.xml
@@ -38,10 +38,6 @@
             <artifactId>org.wso2.carbon.event.output.adapter.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>mqtt-client</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1207,9 +1207,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <encoding>UTF-8</encoding>
+                    <encoding>${project.build.sourceEncoding}</encoding>
                     <source>1.7</source>
                     <target>1.7</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
             <plugin>
@@ -1477,6 +1484,7 @@
         <cxf.version>2.6.1</cxf.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.scm.id>my-scm-server</project.scm.id>
 
         <!-- Spark dependency versions start-->
@@ -1542,8 +1550,6 @@
         <powermock.version>1.6.4</powermock.version>
         <org.jacoco.ant.version>0.7.5.201505241946</org.jacoco.ant.version>
 
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>


### PR DESCRIPTION
## Purpose
> The build is failing due to encoding issues in the builder machine.

## Goals
> Avoid platform dependency

## Approach
> Force encoding to UTF-8 in code level

## Other commits
> Removing duplicate dependencies in pom
