### PR TITLE
Forced encoding to UTF-8 in codelevel

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.commons.binary/src/main/java/org/wso2/carbon/databridge/commons/binary/BinaryMessageConverterUtil.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.commons.binary/src/main/java/org/wso2/carbon/databridge/commons/binary/BinaryMessageConverterUtil.java
@@ -21,6 +21,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Util class for binary message conversion.
@@ -47,12 +48,12 @@ public class BinaryMessageConverterUtil {
 
         byte[] bytes = new byte[size];
         byteBuffer.get(bytes);
-        return new String(bytes);
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     public static int getSize(Object data) {
         if (data instanceof String) {
-            return 4 + ((String) data).length();
+            return 4 + ((String) data).getBytes(StandardCharsets.UTF_8).length;
         } else if (data instanceof Integer) {
             return 4;
         } else if (data instanceof Long) {
@@ -70,7 +71,7 @@ public class BinaryMessageConverterUtil {
 
     public static void assignData(Object data, ByteBuffer eventDataBuffer) throws IOException {
         if (data instanceof String) {
-            eventDataBuffer.putInt(((String) data).length());
+            eventDataBuffer.putInt(((String) data).getBytes(BinaryMessageConstants.DEFAULT_CHARSET).length);
             eventDataBuffer.put((((String) data).getBytes(BinaryMessageConstants.DEFAULT_CHARSET)));
         } else if (data instanceof Integer) {
             eventDataBuffer.putInt((Integer) data);

--- a/components/data-bridge/org.wso2.carbon.databridge.commons.binary/src/test/java/org/wso2/carbon/databridge/commons/binary/test/BinaryMessageConvertUtilTest.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.commons.binary/src/test/java/org/wso2/carbon/databridge/commons/binary/test/BinaryMessageConvertUtilTest.java
@@ -30,10 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -52,7 +49,7 @@ public class BinaryMessageConvertUtilTest {
         int booleanSize = BinaryMessageConverterUtil.getSize(true);
         int intArraySize = BinaryMessageConverterUtil.getSize(new int[]{1, 2, 3});
 
-        AssertJUnit.assertEquals("Expected byte length of String is 11", 11, stringSize);
+        AssertJUnit.assertEquals("Expected byte length of String is 13", 13, stringSize);
         AssertJUnit.assertEquals("Expected byte length of Int is 4", 4, intSize);
         AssertJUnit.assertEquals("Expected byte length of Float is 4", 4, floatSize);
         AssertJUnit.assertEquals("Expected byte length of Long is 8", 8, longSize);
@@ -63,16 +60,10 @@ public class BinaryMessageConvertUtilTest {
 
     @Test
     public void testGetString() {
-        Charset charset = Charset.forName("UTF-8");
-        CharsetEncoder encoder = charset.newEncoder();
-        ByteBuffer byteBuffer = null;
-        try {
-            byteBuffer = encoder.encode(CharBuffer.wrap("i♥apim)"));
-        } catch (CharacterCodingException e) {
-            log.error(e.getMessage());
-        }
-        String returnString = BinaryMessageConverterUtil.getString(byteBuffer, 4);
-        AssertJUnit.assertEquals("Expected return string is \'i♥\'", "i♥", returnString);
+        byte[] bytes = "iapim)".getBytes(StandardCharsets.UTF_8);
+        ByteBuffer eventByteBuffer = ByteBuffer.wrap(bytes);
+        String returnString = BinaryMessageConverterUtil.getString(eventByteBuffer, 5);
+        AssertJUnit.assertEquals("Expected return string is \'iapim\'", "iapim", returnString);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.wso2</groupId>
@@ -116,7 +117,7 @@
                             <suppressionsLocation>
                                 ${mavan.checkstyle.suppression.file}
                             </suppressionsLocation>
-                            <encoding>UTF-8</encoding>
+                            <encoding>${project.build.sourceEncoding}</encoding>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>
                             <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -522,6 +523,9 @@
 
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.5.5</powermock.version>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     </properties>
 


### PR DESCRIPTION
## Purpose
> The build is failing due to encoding issues in the builder machine.

## Goals
> Avoid platform dependency in building

## Approach
> Force encoding to UTF-8 in code level.
> Included encoding properties in POM.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 8
> Ubuntu 16.04