### PR TITLE
Adding parameter to handle cutoff value for profileReceiver

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/DataBridge.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/DataBridge.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.databridge.core;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.databridge.commons.StreamDefinition;
@@ -72,6 +73,7 @@ public class DataBridge implements DataBridgeSubscriberService, DataBridgeReceiv
     private AtomicInteger totalEventCounter;
     private long startTime;
     private boolean isProfileReceiver;
+    private int cutoff = 100000;
 
     public DataBridge(AuthenticationHandler authenticationHandler,
                       AbstractStreamDefinitionStore streamDefinitionStore,
@@ -81,11 +83,17 @@ public class DataBridge implements DataBridgeSubscriberService, DataBridgeReceiv
         authenticatorHandler = authenticationHandler;
         authenticator = new Authenticator(authenticationHandler, dataBridgeConfiguration);
         String profileReceiver = System.getProperty("profileReceiver");
+        String receiverStatsCutoff = System.getProperty("receiverStatsCutoff");
+
         if (profileReceiver != null && profileReceiver.equalsIgnoreCase("true")) {
             isProfileReceiver = true;
             eventsReceived = new AtomicInteger();
             totalEventCounter = new AtomicInteger();
             startTime = 0;
+
+            if (receiverStatsCutoff != null && StringUtils.isNumeric(receiverStatsCutoff)) {
+                this.cutoff = Integer.parseInt(receiverStatsCutoff);
+            }
         }
     }
 
@@ -106,11 +114,17 @@ public class DataBridge implements DataBridgeSubscriberService, DataBridgeReceiv
             authenticatorHandler = authenticationHandler;
             authenticator = new Authenticator(authenticationHandler, dataBridgeConfiguration);
             String profileReceiver = System.getProperty("profileReceiver");
+            String receiverStatsCutoff = System.getProperty("receiverStatsCutoff");
+
             if (profileReceiver != null && profileReceiver.equalsIgnoreCase("true")) {
                 isProfileReceiver = true;
                 eventsReceived = new AtomicInteger();
                 totalEventCounter = new AtomicInteger();
                 startTime = 0;
+
+                if (receiverStatsCutoff != null && StringUtils.isNumeric(receiverStatsCutoff)) {
+                    this.cutoff = Integer.parseInt(receiverStatsCutoff);
+                }
             }
     }
 
@@ -256,9 +270,9 @@ public class DataBridge implements DataBridgeSubscriberService, DataBridgeReceiv
     private void endTimeMeasurement(int eventsNum) {
         if (isProfileReceiver) {
             eventsReceived.addAndGet(eventsNum);
-            if (eventsReceived.get() > 100000) {
+            if (eventsReceived.get() > cutoff) {
                 synchronized (this) {
-                    if (eventsReceived.get() > 100000) {
+                    if (eventsReceived.get() > cutoff) {
                         DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
                         Date date = new Date();
 


### PR DESCRIPTION
## Purpose
> Set cutoff value to print the throughput of the vent receiver

## Goals
> Print logs for each set of events as given by cutoff value.

## Approach
> Start the server by giving providing "receiverStatsCutoff" as the system property. (eg: ./wso2server.sh  -DreceiverStatsCutoff=10000 )
