### PR TITLE
Added additional error logs to print when invalid hostname is specified

### DIFF
--- a/components/event-processor-manager/org.wso2.carbon.event.processor.manager.core/src/main/java/org/wso2/carbon/event/processor/manager/core/internal/CarbonEventManagementService.java
+++ b/components/event-processor-manager/org.wso2.carbon.event.processor.manager.core/src/main/java/org/wso2/carbon/event/processor/manager/core/internal/CarbonEventManagementService.java
@@ -91,6 +91,19 @@ public class CarbonEventManagementService implements EventManagementService {
             isWorkerNode = haConfiguration.isWorkerNode();
             isPresenterNode = haConfiguration.isPresenterNode();
             if (isWorkerNode) {
+
+                if(! validateHostName(haConfiguration.getEventSyncConfig().getHostName())){
+                    log.error("Hostname : "+ haConfiguration.getEventSyncConfig().getHostName() +" defined for " +
+                            "eventSync configuration is invalid. Please add proper IP address " +
+                            "of the node. This IP address is used by other nodes in the cluster to communicate.");
+                }
+
+                if(! validateHostName(haConfiguration.getManagementConfig().getHostName())){
+                    log.error("Hostname : "+ haConfiguration.getManagementConfig().getHostName() +" defined for " +
+                            "management configuration is invalid. Please add proper IP " +
+                            "address of the node. This IP address is used by other nodes in the cluster to communicate.");
+                }
+
                 // Persistence Configuration.
                 PersistenceConfiguration persistConfig = managementModeInfo.getPersistenceConfiguration();
                 if (persistConfig != null) {
@@ -104,6 +117,12 @@ public class CarbonEventManagementService implements EventManagementService {
                 receiverEventHandler.startServer(haConfiguration.getEventSyncConfig());
             }
             if (isPresenterNode && !isWorkerNode) {
+                if(! validateHostName(haConfiguration.getLocalPresenterConfig().getHostName())){
+                    log.error("Hostname : "+ haConfiguration.getLocalPresenterConfig().getHostName() +" defined for " +
+                            "presentation purpose is invalid. Please add proper IP address of the " +
+                            "node. This IP address is used by other nodes in the cluster to communicate.");
+                }
+
                 presenterEventHandler.startServer(haConfiguration.getLocalPresenterConfig());
             }
         } else if (mode == Mode.SingleNode) {
@@ -129,6 +148,12 @@ public class CarbonEventManagementService implements EventManagementService {
                 presenterEventHandler.startServer(distributedConfiguration.getLocalPresenterConfig());
             }
         }
+    }
+
+    private boolean validateHostName(String hostname) {
+
+        return !(hostname.trim().equals("0.0.0.0") || hostname.trim().equals("localhost") ||
+                hostname.trim().equals("127.0.0.1") || hostname.trim().equals("::1"));
     }
 
     public void init(HazelcastInstance hazelcastInstance) {


### PR DESCRIPTION
## Purpose
> Print error logs when defining localhost, 0.0.0.0, 12.0.0.1 for IP adress when clustering is configured 

## Goals
> To explicitly log the errors and avoid unnecessary issues in the deployment in the longer run. 