### PR TITLE
Add API to get assigned roles to a permission

### DIFF
--- a/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/PermissionProvider.java
+++ b/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/PermissionProvider.java
@@ -23,6 +23,8 @@ import org.wso2.carbon.analytics.permissions.bean.Permission;
 import org.wso2.carbon.analytics.permissions.bean.Role;
 import org.wso2.carbon.analytics.permissions.exceptions.PermissionException;
 
+import java.util.List;
+
 /**
  * Permission provider interface.
  */
@@ -78,4 +80,13 @@ public interface PermissionProvider {
      * @throws PermissionException
      */
     boolean hasPermission(String username, Permission permission) throws PermissionException;
+
+    /**
+     * Get list of roles which has a permission granted.
+     *
+     * @param permission
+     * @return
+     * @throws PermissionException
+     */
+    List<Role> getGrantedRoles(Permission permission) throws PermissionException;
 }

--- a/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/internal/dao/PermissionsDAO.java
+++ b/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/internal/dao/PermissionsDAO.java
@@ -32,6 +32,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -251,11 +252,11 @@ public class PermissionsDAO {
      * @return
      */
     public List<Role> getGrantedRoles(Permission permission) {
-        List<Role> roles = Collections.emptyList();
+        List<Role> roles = new ArrayList<>();
         Connection conn = null;
         PreparedStatement ps = null;
         ResultSet resultSet = null;
-        String query = "SELECT * FROM ROLE_PERMISSIONS WHERE APP_NAME = ? AND PERMISSION_STRING = ?";
+        String query = "SELECT ROLE_ID FROM ROLE_PERMISSIONS WHERE APP_NAME = ? AND PERMISSION_STRING = ?";
 
         try {
             conn = getConnection();


### PR DESCRIPTION
## Purpose
In the common permission provider there is no way to get list of roles which were assigned to a particular permission. 

## Goals
This change introduces an API in the `PermissionProvider` get list of roles which have a given permission granted.

## Approach
This introduces a following API in the `PermissionProvider` to get list of roles.
```
 List<Role> getGrantedRoles(Permission permission) throws PermissionException;
```
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes