### PR TITLE
Adding mbean for monitoring the data-bridge event buffer queue.

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/pom.xml
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/pom.xml
@@ -116,6 +116,7 @@
                         <Import-Package>
 			    org.apache.thrift;version="${libthrift.wso2.imp.pkg.version.range}",
                             org.osgi.framework,
+                            javax.management.*,
                             com.lmax.disruptor.*;version="${disruptor.version.range}",
                             ;resolution:=optional
                         </Import-Package>

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -34,7 +34,10 @@ import org.wso2.carbon.databridge.agent.util.DataPublisherUtil;
 import org.wso2.carbon.databridge.commons.Event;
 import org.wso2.carbon.databridge.commons.utils.DataBridgeThreadFactory;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -85,6 +88,16 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
         this.publishingStrategy = agent.getAgentConfiguration().getPublishingStrategy();
         if (!publishingStrategy.equalsIgnoreCase(DataEndpointConstants.SYNC_STRATEGY)) {
             this.eventQueue = new EventQueue(agent.getAgentConfiguration().getQueueSize());
+            MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+            try {
+                ObjectName mbeanEventQueue = new ObjectName("org.wso2.carbon:00=analytics," +
+                        "01=DATABRIDGE_AGENT_EVENT_QUEUE " + this.hashCode());
+                if (!platformMBeanServer.isRegistered(mbeanEventQueue)) {
+                    platformMBeanServer.registerMBean(this.eventQueue, mbeanEventQueue);
+                }
+            } catch (Exception e) {
+                log.error("Unable to create DATABRIDGE_AGENT_EVENT_QUEUE stat MXBean: " + e.getMessage(), e);
+            }
         }
         this.reconnectionService.scheduleAtFixedRate(new ReconnectionTask(), reconnectionInterval,
                 reconnectionInterval, TimeUnit.SECONDS);
@@ -173,7 +186,7 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
         }
     }
 
-    class EventQueue {
+    class EventQueue implements EventQueueMXBean {
         private RingBuffer<WrappedEventFactory.WrappedEvent> ringBuffer = null;
         private Disruptor<WrappedEventFactory.WrappedEvent> eventQueueDisruptor = null;
         private ExecutorService eventQueuePool = null;
@@ -236,6 +249,24 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
                     }
                 }
             } while (isActiveDataEndpointExists());
+        }
+
+        @Override
+        public int getRingBufferSize() {
+            if (ringBuffer != null) {
+                return ringBuffer.getBufferSize();
+            } else {
+                return 0;
+            }
+        }
+
+        @Override
+        public long getRingBufferRemainingCapacity() {
+            if (ringBuffer != null) {
+                return ringBuffer.remainingCapacity();
+            } else {
+                return 0;
+            }
         }
 
         private void shutdown() {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/EventQueueMXBean.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/EventQueueMXBean.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.databridge.agent.endpoint;
+
+/**
+ * This interface hold operation to get EventQueue buffer size and remaining capacity.
+ */
+public interface EventQueueMXBean {
+    /**
+     * This will return buffer size of the event queue.
+     *
+     * @return ringBufferSize of the event queue.
+     */
+    int getRingBufferSize();
+
+    /**
+     * This will return remaining capacity of the event queue.
+     *
+     * @return ringBufferRemainingCapacity of the event queue.
+     */
+    long getRingBufferRemainingCapacity();
+}


### PR DESCRIPTION
## Purpose
> Currently, there is no way to monitoring event queue details(remaining capacity) in the DAS 3.1.0 data bridge agent groups.

## Goals
> Adding MBean for monitoring the data-bridge agent ring buffer event queue.

## Approach
> Mbean Object Name: org.wso2.carbon:00=analytics,01=DATABRIDGE_AGENT_EVENT_QUEUE
Included Following two attributes:
RingBufferSize
RingBufferRemainingCapacity