### PR TITLE
Error message parsing is generified in external Idpclient and fixed NPE in configs reader

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
@@ -473,8 +473,7 @@ public class ExternalIdPClient implements IdPClient {
         if (response != null && response.body() != null) {
             try {
                 String errorDescription = new Gson().fromJson(response.body().toString(), JsonElement.class)
-                        .getAsJsonObject().get("Errors").getAsJsonArray().get(0).getAsJsonObject().get("description")
-                        .getAsString();
+                        .getAsJsonObject().getAsString();
                 errorMessage.append(errorDescription);
             } catch (Exception ex) {
                 LOG.error("Error occurred while parsing error response. Response: '" + response.body().toString() +

--- a/components/authentication/org.wso2.carbon.analytics.msf4j.interceptor.common/src/main/java/org/wso2/carbon/analytics/msf4j/interceptor/common/internal/ServiceComponent.java
+++ b/components/authentication/org.wso2.carbon.analytics.msf4j.interceptor.common/src/main/java/org/wso2/carbon/analytics/msf4j/interceptor/common/internal/ServiceComponent.java
@@ -59,13 +59,12 @@ public class ServiceComponent {
             String exclude = idPClientConfiguration.getProperties().get(IdPClientConstants.EXCLUDE_INTERCEPTOR);
             Boolean isInterceptorEnabled = Boolean.parseBoolean(enableInterceptor);
             DataHolder.getInstance().setInterceptorEnabled(isInterceptorEnabled);
-            if (isInterceptorEnabled) {
-                List<String> collect = Arrays.stream(exclude.replaceAll("\\s*", "")
-                                .split(",")).collect(Collectors.toList());
-                DataHolder.getInstance().setExcludeURLList(collect);
-            } else {
-                DataHolder.getInstance().setExcludeURLList(new ArrayList<>());
+            List<String> excludeURLList = new ArrayList<>();
+            if (exclude != null) {
+                excludeURLList =  Arrays.stream(exclude.replaceAll("\\s*", "")
+                        .split(",")).collect(Collectors.toList());
             }
+            DataHolder.getInstance().setExcludeURLList(excludeURLList);
         }
     }
 

--- a/components/authentication/org.wso2.carbon.analytics.msf4j.interceptor.common/src/main/java/org/wso2/carbon/analytics/msf4j/interceptor/common/internal/ServiceComponent.java
+++ b/components/authentication/org.wso2.carbon.analytics.msf4j.interceptor.common/src/main/java/org/wso2/carbon/analytics/msf4j/interceptor/common/internal/ServiceComponent.java
@@ -33,7 +33,6 @@ import org.wso2.carbon.config.provider.ConfigProvider;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * component to get the registered IdPClient OSGi service.
@@ -61,8 +60,7 @@ public class ServiceComponent {
             DataHolder.getInstance().setInterceptorEnabled(isInterceptorEnabled);
             List<String> excludeURLList = new ArrayList<>();
             if (exclude != null) {
-                excludeURLList =  Arrays.stream(exclude.replaceAll("\\s*", "")
-                        .split(",")).collect(Collectors.toList());
+                excludeURLList =  Arrays.asList(exclude.replaceAll("\\s*", "").split(","));
             }
             DataHolder.getInstance().setExcludeURLList(excludeURLList);
         }


### PR DESCRIPTION
## Purpose
Error message parsing is generified in external Idpclient and fixed NPE in configs reader

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes