### PR TITLE
Fixes for issues #433, #434, #435

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LogoutApiServiceImpl.java
+++ b/components/authentication/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/impl/LogoutApiServiceImpl.java
@@ -58,19 +58,22 @@ public class LogoutApiServiceImpl extends LogoutApiService {
                 DataHolder.getInstance().getIdPClient().logout(logoutProperties);
 
                 // Lets invalidate all the cookies saved.
+                NewCookie appContextCookieHttp = AuthUtil
+                        .cookieBuilder(IdPClientConstants.WSO2_SP_TOKEN_1, "", appContext, true, false,
+                                0);
                 NewCookie appContextCookie = AuthUtil
                         .cookieBuilder(IdPClientConstants.WSO2_SP_TOKEN_2, "", appContext, true, true,
-                                IdPClientConstants.COOKIE_EXPIRE_TIME);
+                                0);
 
                 NewCookie refreshTokenCookie = AuthUtil
                         .cookieBuilder(IdPClientConstants.WSO2_SP_REFRESH_TOKEN_1, "", appContext, true, false,
-                                IdPClientConstants.COOKIE_EXPIRE_TIME);
+                                0);
                 NewCookie refreshTokenHttpOnlyCookie = AuthUtil
                         .cookieBuilder(IdPClientConstants.WSO2_SP_REFRESH_TOKEN_2, "", appContext, true, true,
-                                IdPClientConstants.COOKIE_EXPIRE_TIME);
+                                0);
 
                 return Response.ok()
-                        .cookie(appContextCookie, refreshTokenCookie, refreshTokenHttpOnlyCookie)
+                        .cookie(appContextCookieHttp, appContextCookie, refreshTokenCookie, refreshTokenHttpOnlyCookie)
                         .build();
             } catch (IdPClientException e) {
                 LOG.error("Error in logout for uri '" + appName + "', with token, '" + accessToken + "'.", e);

--- a/components/authentication/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
+++ b/components/authentication/org.wso2.carbon.analytics.auth.rest.api/src/main/java/org/wso2/carbon/analytics/auth/rest/api/util/AuthUtil.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.analytics.auth.rest.api.util;
 import org.wso2.carbon.analytics.idp.client.core.utils.IdPClientConstants;
 import org.wso2.carbon.messaging.Headers;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import javax.ws.rs.core.NewCookie;
 
@@ -60,7 +62,7 @@ public class AuthUtil {
     }
 
     public static NewCookie cookieBuilder(String name, String value, String path, boolean isSecure,
-                                          boolean isHttpOnly, String expiresIn) {
+                                          boolean isHttpOnly, int expiresIn) {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append(value).append(COOKIE_PATH_SEPERATOR).append(path).append(COOKIE_VALUE_SEPERATOR);
         if (isHttpOnly) {
@@ -69,9 +71,9 @@ public class AuthUtil {
         if (isSecure) {
             stringBuilder.append(IdPClientConstants.SECURE_COOKIE);
         }
-        if (expiresIn != null && !expiresIn.isEmpty()) {
-            stringBuilder.append(COOKIE_VALUE_SEPERATOR).append(expiresIn);
-        }
+        stringBuilder.append(COOKIE_VALUE_SEPERATOR).append(IdPClientConstants.EXPIRES_COOKIE)
+                .append(ZonedDateTime.now().plusSeconds(expiresIn).format(DateTimeFormatter.RFC_1123_DATE_TIME))
+                .append(COOKIE_VALUE_SEPERATOR);
         return new NewCookie(name, stringBuilder.toString());
     }
 }

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/IdPClientConstants.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/IdPClientConstants.java
@@ -55,7 +55,7 @@ public class IdPClientConstants {
     public static final String COOKIE_HEADER = "Cookie";
     public static final String HTTP_ONLY_COOKIE = "HttpOnly";
     public static final String SECURE_COOKIE = "Secure";
-    public static final String COOKIE_EXPIRE_TIME = "Expires=Thu, 01-Jan-1970 00:00:01 GMT";
+    public static final String EXPIRES_COOKIE = "Expires=";
 
     public static final String BEARER_PREFIX = "Bearer";
     public static final String BASIC_PREFIX = "Basic";

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
@@ -293,7 +293,7 @@ public class ExternalIdPClient implements IdPClient {
                 returnProperties.put(IdPClientConstants.ACCESS_TOKEN, oAuth2TokenInfo.getAccessToken());
                 returnProperties.put(IdPClientConstants.REFRESH_TOKEN, oAuth2TokenInfo.getRefreshToken());
                 returnProperties.put(ExternalIdPClientConstants.TOKEN_ID, oAuth2TokenInfo.getIdToken());
-                returnProperties.put(ExternalIdPClientConstants.EXPIRES_IN,
+                returnProperties.put(IdPClientConstants.VALIDITY_PERIOD,
                         Long.toString(oAuth2TokenInfo.getExpiresIn()));
                 returnProperties.put(ExternalIdPClientConstants.REDIRECT_URL, this.baseUrl + appContext);
 

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
@@ -41,7 +41,7 @@ public class ExternalIdPClientConstants {
     public static final String STATUS_DB_APP_NAME = "status.dashboard.app.name";
     public static final String BR_DB_APP_NAME = "business.rules.app.name";
 
-    public static final String DEFAULT_BASE_URL = "http://localhost:9090";
+    public static final String DEFAULT_BASE_URL = "https://localhost:9643";
     public static final String DEFAULT_KM_TOKEN_URL = "https://localhost:9443/oauth2";
     public static final String DEFAULT_KM_DCR_URL = "https://localhost:9443/identity/connect/register";
     public static final String DEFAULT_KM_CERT_ALIAS = "wso2carbon";


### PR DESCRIPTION
## Purpose
1. Validity period of token cookie is set as the same as that of the token. (Fixes https://github.com/wso2/carbon-analytics-common/issues/433 )
2. Fixed redirect url pointing to worker profile ( Fixes https://github.com/wso2/carbon-analytics-common/issues/434 )
3. Fixed refresh token not being returned in external IdP client. (Fixes https://github.com/wso2/carbon-analytics-common/issues/435 )

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes