### PR TITLE
Support to identify admin role in the user store

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/api/IdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/api/IdPClient.java
@@ -31,6 +31,8 @@ import java.util.Map;
 public interface IdPClient {
     List<Role> getAllRoles() throws IdPClientException;
 
+    Role getAdminRole() throws IdPClientException;
+
     User getUser(String name) throws IdPClientException;
 
     List<Role> getUserRoles(String name) throws IdPClientException;

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/config/UserManagerElement.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/config/UserManagerElement.java
@@ -20,33 +20,23 @@ package org.wso2.carbon.analytics.idp.client.core.utils.config;
 import org.wso2.carbon.config.annotation.Configuration;
 import org.wso2.carbon.config.annotation.Element;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
- * IdP configurations.
+ * User manager Element.
  */
-@Configuration(namespace = "auth.configs", description = "SP Authorization Configuration Parameters")
-public class IdPClientConfiguration {
+@Configuration(description = "User Manager Element")
+public class UserManagerElement {
 
-    @Element(description = "Client Type", required = true)
-    private String type = "local";
+    @Element(description = "Admin Role - Display name of the role defined in the user store", required = true)
+    private String adminRole = "admin";
 
-    @Element(description = "Client properties")
-    private Map<String, String> properties = new HashMap<>();
+    @Element(description = "User Store")
+    private UserStoreElement userStore = new UserStoreElement();
 
-    @Element(description = "User Manager")
-    private UserManagerElement userManager = new UserManagerElement();
-
-    public String getType() {
-        return type;
+    public String getAdminRole() {
+        return adminRole;
     }
 
-    public Map<String, String> getProperties() {
-        return properties;
-    }
-
-    public UserManagerElement getUserManager() {
-        return userManager;
+    public UserStoreElement getUserStore() {
+        return userStore;
     }
 }

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
@@ -71,6 +71,7 @@ public class ExternalIdPClientConstants {
     public static final String REGEX_BASE_END = ".*)";
 
     public static final String FILTER_PREFIX_USER = "userName Eq ";
+    public static final String FILTER_PREFIX_GROUP = "displayName Eq ";
     public static final String EMPTY_STRING = "";
     public static final String RESOURCES = "Resources";
 

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientFactory.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientFactory.java
@@ -122,9 +122,11 @@ public class ExternalIdPClientFactory implements IdPClientFactory {
         SCIM2ServiceStub scimServiceStub = SCIM2ServiceStubFactory
                 .getSCIMServiceStub(idPBaseUrl, idPUserName, idPPassword, idPCertAlias);
 
+        String adminRoleDisplayName = idPClientConfiguration.getUserManager().getAdminRole();
+
         return new ExternalIdPClient(baseUrl, kmTokenUrl + ExternalIdPClientConstants.AUTHORIZE_POSTFIX,
-                grantType, signingAlgo, spAppName, oAuthAppNames, dcrmServiceStub, keyManagerServiceStubs,
-                scimServiceStub);
+                grantType, signingAlgo, adminRoleDisplayName, spAppName, oAuthAppNames, dcrmServiceStub,
+                keyManagerServiceStubs, scimServiceStub);
     }
 
 }

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/impl/SCIM2ServiceStub.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/impl/SCIM2ServiceStub.java
@@ -30,6 +30,9 @@ public interface SCIM2ServiceStub {
     Response searchUser(@Param("query") String query);
 
     @RequestLine("GET /Groups")
-    Response getGroups();
+    Response getAllGroups();
+
+    @RequestLine("GET /Groups?filter={query}")
+    Response getFilteredGroups(@Param("query") String query);
 
 }

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/local/LocalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/local/LocalIdPClient.java
@@ -47,14 +47,16 @@ public class LocalIdPClient implements IdPClient {
     private int sessionTimeout;
     private int rememberMeTimeout;
     private List<User> usersList;
+    private Role adminRole;
     private List<Role> rolesList;
     private int systemLoginCount;
 
-    public LocalIdPClient(int sessionTimeOut, List<User> users, List<Role> roles) {
+    public LocalIdPClient(int sessionTimeOut, List<User> users, List<Role> roles, Role adminRole) {
         this.sessionTimeout = sessionTimeOut * 1000;
         this.systemLoginCount = 0;
         // NOTE: the rememberMe timeout is set at 7 days
         this.rememberMeTimeout = 7 * 24 * 60 * 60 * 1000;
+        this.adminRole = adminRole;
         this.rolesList = roles;
         this.usersList = users;
     }
@@ -62,6 +64,11 @@ public class LocalIdPClient implements IdPClient {
     @Override
     public List<Role> getAllRoles() {
         return rolesList;
+    }
+
+    @Override
+    public Role getAdminRole() {
+        return adminRole;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
No support to identify admin role in the user store. (Fixes https://github.com/wso2/carbon-analytics-common/issues/438)

## Goals
Admin role can be configured in the configurations which will be exposed by the IsPClient interface.

## Approach
Admin role will be identified by it's display name from the 'adminRole' config under userManager.

auth.configs:
&nbsp;&nbsp;userManager:
&nbsp;&nbsp;&nbsp;&nbsp;adminRole: admin
&nbsp;&nbsp;&nbsp;&nbsp;userStore:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;users:
.
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;roles:
.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes