### PR TITLE
Add LoggingControlIntervalInSeconds configuration to data-bridge agent.

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
@@ -169,26 +169,28 @@ public class DataPublisher {
              * we need to start iterating from 2nd element.
              */
             for (int j = 1; j < receiverGroup.length; j++) {
-	            DataEndpointConfiguration endpointConfiguration;
-	            String[] urlParams =  DataPublisherUtil.getProtocolHostPort((String) receiverGroup[j]);
+                DataEndpointConfiguration endpointConfiguration;
+                String[] urlParams = DataPublisherUtil.getProtocolHostPort((String) receiverGroup[j]);
 
-	            if (urlParams[0].equalsIgnoreCase(DataEndpointConfiguration.Protocol.TCP.toString())) {
-		            endpointConfiguration = new DataEndpointConfiguration((String) receiverGroup[j],
-			            (String) authGroup[j], username, password, dataEndpointAgent.getTransportPool(),
-			            dataEndpointAgent.getSecuredTransportPool(),
-			            dataEndpointAgent.getAgentConfiguration().getBatchSize(),
-			            dataEndpointAgent.getAgentConfiguration().getCorePoolSize(),
-			            dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
-			            dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool());
-	            } else {
-		            endpointConfiguration = new DataEndpointConfiguration((String) receiverGroup[j],
-			            (String) authGroup[j], username, password, dataEndpointAgent.getSecuredTransportPool(),
-			            dataEndpointAgent.getSecuredTransportPool(),
-			            dataEndpointAgent.getAgentConfiguration().getBatchSize(),
-			            dataEndpointAgent.getAgentConfiguration().getCorePoolSize(),
-			            dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
-			            dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool());
-	            }
+                if (urlParams[0].equalsIgnoreCase(DataEndpointConfiguration.Protocol.TCP.toString())) {
+                    endpointConfiguration = new DataEndpointConfiguration((String) receiverGroup[j],
+                            (String) authGroup[j], username, password, dataEndpointAgent.getTransportPool(),
+                            dataEndpointAgent.getSecuredTransportPool(),
+                            dataEndpointAgent.getAgentConfiguration().getBatchSize(),
+                            dataEndpointAgent.getAgentConfiguration().getCorePoolSize(),
+                            dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
+                            dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool(),
+                            dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds());
+                } else {
+                    endpointConfiguration = new DataEndpointConfiguration((String) receiverGroup[j],
+                            (String) authGroup[j], username, password, dataEndpointAgent.getSecuredTransportPool(),
+                            dataEndpointAgent.getSecuredTransportPool(),
+                            dataEndpointAgent.getAgentConfiguration().getBatchSize(),
+                            dataEndpointAgent.getAgentConfiguration().getCorePoolSize(),
+                            dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
+                            dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool(),
+                            dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds());
+                }
 
                 DataEndpoint dataEndpoint = dataEndpointAgent.getNewDataEndpoint();
                 dataEndpoint.initialize(endpointConfiguration);

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/AgentConfiguration.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/AgentConfiguration.java
@@ -72,6 +72,8 @@ public class AgentConfiguration {
 
     private String ciphers;
 
+    private int loggingControlIntervalInSeconds;
+
     @XmlElement(name = "Name")
     public String getDataEndpointName() {
         return dataEndpointName;
@@ -285,6 +287,15 @@ public class AgentConfiguration {
 
     public void setCiphers(String ciphers) {
         this.ciphers = ciphers;
+    }
+
+    @XmlElement(name = "LoggingControlIntervalInSeconds")
+    public int getLoggingControlIntervalInSeconds() {
+        return loggingControlIntervalInSeconds;
+    }
+
+    public void setLoggingControlIntervalInSeconds(int loggingControlIntervalInSeconds) {
+        this.loggingControlIntervalInSeconds = loggingControlIntervalInSeconds;
     }
 
     /**

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/DataEndpointConfiguration.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/DataEndpointConfiguration.java
@@ -48,6 +48,8 @@ public class DataEndpointConfiguration {
 
     private int keepAliveTimeInPool;
 
+    private long loggingControlIntervalInSeconds;
+
     public enum Protocol {
         TCP, SSL;
 
@@ -60,7 +62,8 @@ public class DataEndpointConfiguration {
     public DataEndpointConfiguration(String receiverURL, String authURL, String username, String password,
                                      GenericKeyedObjectPool transportPool,
                                      GenericKeyedObjectPool securedTransportPool,
-                                     int batchSize, int corePoolSize, int maxPoolSize, int keepAliveTimeInPool) {
+                                     int batchSize, int corePoolSize, int maxPoolSize, int keepAliveTimeInPoo,
+                                     int loggingControlIntervalInSeconds) {
         this.receiverURL = receiverURL;
         this.authURL = authURL;
         this.username = username;
@@ -73,6 +76,7 @@ public class DataEndpointConfiguration {
         this.corePoolSize = corePoolSize;
         this.maxPoolSize = maxPoolSize;
         this.keepAliveTimeInPool = keepAliveTimeInPool;
+        this.loggingControlIntervalInSeconds = (long) loggingControlIntervalInSeconds;
     }
 
     public String getReceiverURL() {
@@ -135,6 +139,10 @@ public class DataEndpointConfiguration {
 
     public int getBatchSize() {
         return batchSize;
+    }
+
+    public long getLoggingControlIntervalInSeconds() {
+        return loggingControlIntervalInSeconds;
     }
 }
 

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
@@ -23,6 +23,7 @@ import org.apache.commons.pool.impl.GenericKeyedObjectPool;
 import org.wso2.carbon.databridge.agent.conf.DataEndpointConfiguration;
 import org.wso2.carbon.databridge.agent.exception.DataEndpointAuthenticationException;
 import org.wso2.carbon.databridge.agent.exception.DataEndpointException;
+import org.wso2.carbon.databridge.agent.exception.DataEndpointLoginException;
 import org.wso2.carbon.databridge.agent.util.DataEndpointConstants;
 import org.wso2.carbon.databridge.commons.Event;
 import org.wso2.carbon.databridge.commons.exception.SessionTimeoutException;
@@ -181,7 +182,7 @@ public abstract class DataEndpoint {
      * @throws DataEndpointAuthenticationException
      */
     protected abstract String login(Object client, String userName, String password)
-            throws DataEndpointAuthenticationException;
+            throws DataEndpointAuthenticationException, DataEndpointLoginException;
 
     /**
      * Logout from the endpoint.

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointConnectionWorker.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointConnectionWorker.java
@@ -22,6 +22,13 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.databridge.agent.conf.DataEndpointConfiguration;
 import org.wso2.carbon.databridge.agent.exception.DataEndpointAuthenticationException;
 import org.wso2.carbon.databridge.agent.exception.DataEndpointException;
+import org.wso2.carbon.databridge.agent.exception.DataEndpointLoginException;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * DataEndpoint Connection worker class implementation.
@@ -35,6 +42,16 @@ public class DataEndpointConnectionWorker implements Runnable {
 
     private DataEndpoint dataEndpoint;
 
+    private ScheduledExecutorService loggingControlScheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+
+    private ScheduledFuture<?> loggingSchedule;
+
+    private LoggingTask loggingTask = new LoggingTask();
+
+    private AtomicBoolean loggingControlFlag = new AtomicBoolean(true);
+
+    private boolean isLoggingControl = false;
+
     @Override
     public void run() {
         if (isInitialized()) {
@@ -42,6 +59,16 @@ public class DataEndpointConnectionWorker implements Runnable {
                 connect();
                 dataEndpoint.activate();
             } catch (DataEndpointAuthenticationException e) {
+                if (isLoggingControl) {
+                    if (loggingControlFlag.get()) {
+                        log.error("Error while trying to connect to the endpoint. " + e.getErrorMessage(), e);
+                        loggingControlFlag.set(false);
+                    }
+                } else {
+                    log.error("Error while trying to connect to the endpoint. " + e.getErrorMessage(), e);
+                }
+                dataEndpoint.deactivate();
+            } catch (DataEndpointLoginException e) {
                 log.error("Error while trying to connect to the endpoint. " + e.getErrorMessage(), e);
                 dataEndpoint.deactivate();
             }
@@ -82,10 +109,15 @@ public class DataEndpointConnectionWorker implements Runnable {
         } else {
             throw new DataEndpointException("Already data endpoint is configured for the connection worker");
         }
+
+        if (dataEndpointConfiguration.getLoggingControlIntervalInSeconds() != 0) {
+            isLoggingControl = true;
+            scheduledLoggingTask();
+        }
     }
 
 
-    private void connect() throws DataEndpointAuthenticationException {
+    private void connect() throws DataEndpointAuthenticationException, DataEndpointLoginException {
         Object client = null;
         try {
             client = this.dataEndpointConfiguration.getSecuredTransportPool().
@@ -95,8 +127,13 @@ public class DataEndpointConnectionWorker implements Runnable {
                             dataEndpointConfiguration.getPassword());
             dataEndpointConfiguration.setSessionId(sessionId);
         } catch (Throwable e) {
-            log.error(e.getMessage(), e);
-            throw new DataEndpointAuthenticationException("Cannot borrow client for " + dataEndpointConfiguration.getAuthURL(), e);
+            if (e instanceof DataEndpointLoginException) {
+                throw new DataEndpointLoginException(
+                        "Cannot borrow client for " + dataEndpointConfiguration.getAuthURL() + ".", e);
+            } else {
+                throw new DataEndpointAuthenticationException(
+                        "Cannot borrow client for " + dataEndpointConfiguration.getAuthURL(), e);
+            }
         } finally {
             try {
                 this.dataEndpointConfiguration.getSecuredTransportPool().returnObject(dataEndpointConfiguration.getAuthKey(), client);
@@ -119,6 +156,9 @@ public class DataEndpointConnectionWorker implements Runnable {
             log.warn("Cannot connect to the server at " + dataPublisherConfiguration.getAuthURL() + ", for user: " + dataPublisherConfiguration.getUsername());
         } finally {
             try {
+                if (null != loggingControlScheduledExecutorService) {
+                    loggingControlScheduledExecutorService.shutdown();
+                }
                 this.dataEndpointConfiguration.getSecuredTransportPool().returnObject(dataPublisherConfiguration.getAuthKey(), client);
             } catch (Exception e) {
                 this.dataEndpointConfiguration.getSecuredTransportPool().clear(dataPublisherConfiguration.getAuthKey());
@@ -128,6 +168,17 @@ public class DataEndpointConnectionWorker implements Runnable {
 
     private boolean isInitialized() {
         return dataEndpoint != null && dataEndpointConfiguration != null;
+    }
+
+    private void scheduledLoggingTask() {
+        loggingSchedule = loggingControlScheduledExecutorService.scheduleAtFixedRate(loggingTask, 0,
+                dataEndpointConfiguration.getLoggingControlIntervalInSeconds(), TimeUnit.SECONDS );
+    }
+
+    private class LoggingTask implements Runnable {
+        @Override public void run() {
+            loggingControlFlag.set(true);
+        }
     }
 
 }

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/binary/BinaryDataEndpoint.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/binary/BinaryDataEndpoint.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.databridge.agent.endpoint.binary;
 import org.wso2.carbon.databridge.agent.endpoint.DataEndpoint;
 import org.wso2.carbon.databridge.agent.exception.DataEndpointAuthenticationException;
 import org.wso2.carbon.databridge.agent.exception.DataEndpointException;
+import org.wso2.carbon.databridge.agent.exception.DataEndpointLoginException;
 import org.wso2.carbon.databridge.commons.Event;
 import org.wso2.carbon.databridge.commons.exception.SessionTimeoutException;
 import org.wso2.carbon.databridge.commons.exception.UndefinedEventTypeException;
@@ -35,7 +36,8 @@ import static org.wso2.carbon.databridge.agent.endpoint.binary.BinaryEventSender
 public class BinaryDataEndpoint extends DataEndpoint {
 
     @Override
-    protected String login(Object client, String userName, String password) throws DataEndpointAuthenticationException {
+    protected String login(Object client, String userName, String password)
+            throws DataEndpointAuthenticationException, DataEndpointLoginException {
         Socket socket = (Socket) client;
         try {
             sendBinaryLoginMessage(socket, userName, password);
@@ -44,7 +46,7 @@ public class BinaryDataEndpoint extends DataEndpoint {
             if (e instanceof DataEndpointAuthenticationException) {
                 throw (DataEndpointAuthenticationException) e;
             } else {
-                throw new DataEndpointAuthenticationException("Error while trying to login to data receiver :"
+                throw new DataEndpointLoginException("Error while trying to login to data receiver :"
                         + socket.getRemoteSocketAddress().toString(), e);
             }
         }

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/exception/DataEndpointLoginException.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/exception/DataEndpointLoginException.java
@@ -1,0 +1,44 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.carbon.databridge.agent.exception;
+
+/**
+ * Exception to be thrown when login fail due to wrong user name or password.
+ */
+public class DataEndpointLoginException extends Exception{
+    private String errorMessage;
+
+    public DataEndpointLoginException(String message) {
+        super(message);
+        errorMessage = message;
+    }
+
+    public DataEndpointLoginException(String message, Throwable cause) {
+        super(message, cause);
+        errorMessage = message;
+    }
+
+    public DataEndpointLoginException(Throwable cause) {
+        super(cause);
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/DataBrigdeWorkerTestCase.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/DataBrigdeWorkerTestCase.java
@@ -64,7 +64,8 @@ public class DataBrigdeWorkerTestCase {
                         getAgentConfiguration().getBatchSize(),
                         dataEndpointAgent.getAgentConfiguration().getCorePoolSize(),
                         dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
-                        dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool());
+                        dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool(),
+                        dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds());
         DataEndpoint dataEndpoint = dataEndpointAgent.getNewDataEndpoint();
         dataEndpoint.initialize(endpointConfiguration);
         dataEndpointConnectionWorker.initialize(dataEndpoint, endpointConfiguration);


### PR DESCRIPTION
## Purpose
> To control the logging interval of error message when receiving instance is inactive. 

## Approach
> Introduce a configuration "LoggingControlIntervalInSeconds" to set the logging interval when receiving data end is inactive.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes