### PR TITLE
Fixes #486 by adding configurations to send user tenant name in request

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
@@ -100,7 +100,7 @@ public class ExternalIdPClient implements IdPClient {
         return str.replace('\n', '_').replace('\r', '_');
     }
 
-    public void init() throws IdPClientException {
+    public void init(String kmUserName) throws IdPClientException {
         this.oAuthAppDAO.init();
         this.oAuthAppDAO.createTable();
         for (Map.Entry<String, OAuthApplicationInfo> oAuthApplicationInfoEntry : this.oAuthAppInfoMap.entrySet()) {
@@ -121,7 +121,7 @@ public class ExternalIdPClient implements IdPClient {
                 this.oAuthAppInfoMap.replace(oAuthApplicationInfoEntry.getKey(), persistedOAuthApp);
             } else {
                 registerApplication(oAuthApplicationInfoEntry.getKey(),
-                        oAuthApplicationInfoEntry.getValue().getClientName());
+                        oAuthApplicationInfoEntry.getValue().getClientName(), kmUserName);
             }
         }
     }
@@ -468,7 +468,8 @@ public class ExternalIdPClient implements IdPClient {
         }
     }
 
-    private void registerApplication(String appContext, String clientName) throws IdPClientException {
+    private void registerApplication(String appContext, String clientName, String kmUserName)
+            throws IdPClientException {
         List<String> grantTypes = new ArrayList<>();
         grantTypes.add(IdPClientConstants.PASSWORD_GRANT_TYPE);
         grantTypes.add(IdPClientConstants.AUTHORIZATION_CODE_GRANT_TYPE);
@@ -493,6 +494,7 @@ public class ExternalIdPClient implements IdPClient {
         dcrClientInfo.setGrantTypes(grantTypes);
         dcrClientInfo.addCallbackUrl(callBackUrl);
         dcrClientInfo.setUserinfoSignedResponseAlg(signingAlgo);
+        dcrClientInfo.setExtParamOwner(kmUserName);
 
         Response response = dcrmServiceStub.registerApplication(dcrClientInfo);
         if (response == null) {

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
@@ -49,6 +49,7 @@ public class ExternalIdPClientConstants {
     public static final String BR_DB_CLIENT_SECRET = "businessRulesClientSecret";
     public static final String CACHE_TIMEOUT = "cacheTimeout";
     public static final String DATABASE_NAME = "databaseName";
+    public static final String DCR_APP_OWNER = "dcrAppOwner";
 
     public static final String DEFAULT_BASE_URL = "https://localhost:9643";
     public static final String DEFAULT_KM_TOKEN_URL = "https://localhost:9443/oauth2";

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientFactory.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientFactory.java
@@ -109,6 +109,7 @@ public class ExternalIdPClientFactory implements IdPClientFactory {
                 ExternalIdPClientConstants.DEFAULT_KM_PASSWORD);
         String kmTokenUrl = properties.getOrDefault(ExternalIdPClientConstants.KM_TOKEN_URL,
                 ExternalIdPClientConstants.DEFAULT_KM_TOKEN_URL);
+        String dcrAppOwner = properties.getOrDefault(ExternalIdPClientConstants.DCR_APP_OWNER, kmUsername);
 
         String idPBaseUrl = properties.getOrDefault(ExternalIdPClientConstants.IDP_BASE_URL,
                 ExternalIdPClientConstants.DEFAULT_IDP_BASE_URL);
@@ -185,7 +186,7 @@ public class ExternalIdPClientFactory implements IdPClientFactory {
                 kmTokenUrl + ExternalIdPClientConstants.AUTHORIZE_POSTFIX, grantType, signingAlgo,
                 adminRoleDisplayName, oAuthAppInfoMap, cacheTimeout, oAuthAppDAO, dcrmServiceStub,
                 keyManagerServiceStubs, scimServiceStub);
-        externalIdPClient.init();
+        externalIdPClient.init(dcrAppOwner);
         return externalIdPClient;
     }
 

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/dto/DCRClientInfo.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/dto/DCRClientInfo.java
@@ -55,6 +55,8 @@ public final class DCRClientInfo {
     private String jwksUri;
     @SerializedName("userinfo_signed_response_alg")
     private String userinfoSignedResponseAlg;
+    @SerializedName("ext_param_owner")
+    private String extParamOwner;
 
     public String getClientId() {
         return clientId;
@@ -178,6 +180,10 @@ public final class DCRClientInfo {
             redirectURIs = new ArrayList<>();
         }
         redirectURIs.add(callback);
+    }
+
+    public void setExtParamOwner(String extParamOwner) {
+        this.extParamOwner = extParamOwner;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/carbon-analytics-common/issues/486

## Goals
Adding 'ext_param_owner' param in the DCR request.

## Approach
Adding configurations to input tenant name in the 'auth.configs'

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes