### PR TITLE
Add setter method in Queries Bean, Change the logging framework for slf4j.

### DIFF
--- a/components/org.wso2.carbon.database.query.manager/pom.xml
+++ b/components/org.wso2.carbon.database.query.manager/pom.xml
@@ -35,8 +35,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.log4j.wso2</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.config</groupId>

--- a/components/org.wso2.carbon.database.query.manager/src/main/java/org/wso2/carbon/database/query/manager/QueryProvider.java
+++ b/components/org.wso2.carbon.database.query.manager/src/main/java/org/wso2/carbon/database/query/manager/QueryProvider.java
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.database.query.manager;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wso2.carbon.database.query.manager.config.Queries;
 import org.wso2.carbon.database.query.manager.exception.QueryMappingNotAvailableException;
 
@@ -33,7 +34,7 @@ import java.util.Set;
  * deployment.yaml config.
  */
 public class QueryProvider {
-    private static final Logger LOGGER = Logger.getLogger(QueryProvider.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(QueryProvider.class);
     private static final String DEFAULT_TYPE = "default";
 
     /**

--- a/components/org.wso2.carbon.database.query.manager/src/main/java/org/wso2/carbon/database/query/manager/config/Queries.java
+++ b/components/org.wso2.carbon.database.query.manager/src/main/java/org/wso2/carbon/database/query/manager/config/Queries.java
@@ -60,4 +60,16 @@ public class Queries {
     public Map<String, String> getMappings() {
         return this.mappings;
     }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public void setMappings(Map<String, String> mappings) {
+        this.mappings = mappings;
+    }
 }


### PR DESCRIPTION
## Purpose
> For test cases we need to set mock values into Queries bean class. 
Fix the issue in provider logging where we need to use slf4j as common login framework in C5 components.

## Goals
> Fix the logging framework compatibility issue and Provider testable support.