### PR TITLE
Add HttpClientService which by default ignore hostname verification

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/api/AnalyticsHttpClientBuilderService.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/api/AnalyticsHttpClientBuilderService.java
@@ -16,26 +16,17 @@
  * under the License.
  */
 
-package org.wso2.carbon.analytics.idp.client.core;
+package org.wso2.carbon.analytics.idp.client.core.api;
 
 import feign.Client;
 
 /**
- * Builder class used to build feign client.
+ * This interface is the Feign Client Builder Service, which create a fiegn client for each Http Service, where it is
+ * necessary. The reason for having a seperate Class is to encapsulate the hostname verification logic from their
+ * HTTP service logic.
  */
-public class ClientBuilder {
-
-    private boolean isHostnameVerifierEnabled;
-
-    public ClientBuilder(boolean isEnabled) {
-        this.isHostnameVerifierEnabled = isEnabled;
-    }
-
-    public Client.Default createClient() {
-        if (isHostnameVerifierEnabled) {
-            return new Client.Default(null, (hostName, sslSession) -> true);
-        } else {
-            return new Client.Default(null, null);
-        }
-    }
+public interface AnalyticsHttpClientBuilderService {
+    public Client newDefaultClientInstance();
+    public <T> T build(String username, String password, int connectTimeoutMillis,
+                       int readTimeoutMillis, Class<T> target, String url);
 }

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/internal/AnalyticsHttpClientBuilderServiceImpl.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/internal/AnalyticsHttpClientBuilderServiceImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.analytics.idp.client.core.internal;
+
+import feign.Client;
+import feign.Feign;
+import feign.Request;
+import feign.auth.BasicAuthRequestInterceptor;
+import feign.gson.GsonDecoder;
+import feign.gson.GsonEncoder;
+
+import org.wso2.carbon.analytics.idp.client.core.api.AnalyticsHttpClientBuilderService;
+
+
+/**
+ * This class is the Feign Client Builder Service, which create a fiegn client for each Http Service, where it is
+ * necessary. The reason for having a seperate Class is to encapsulate the hostname verification logic from their
+ * HTTP service logic.
+ */
+public class AnalyticsHttpClientBuilderServiceImpl implements AnalyticsHttpClientBuilderService {
+
+    private boolean isHostnameVerifierEnabled;
+
+    public AnalyticsHttpClientBuilderServiceImpl(boolean isEnabled) {
+        this.isHostnameVerifierEnabled = isEnabled;
+    }
+
+    public Client newDefaultClientInstance() {
+        if (isHostnameVerifierEnabled) {
+            return new Client.Default(null, (hostName, sslSession) -> true);
+        } else {
+            return new Client.Default(null, null);
+        }
+    }
+
+    public <T> T build(String username, String password, int connectTimeoutMillis,
+                       int readTimeoutMillis, Class<T> target, String url) {
+        return Feign.builder().requestInterceptor(new BasicAuthRequestInterceptor(username, password))
+                .encoder(new GsonEncoder()).decoder(new GsonDecoder())
+                .options(new Request.Options(connectTimeoutMillis, readTimeoutMillis))
+                .client(newDefaultClientInstance())
+                .target(target, url);
+    }
+}

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/internal/AnalyticsHttpClientBuilderServiceImpl.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/internal/AnalyticsHttpClientBuilderServiceImpl.java
@@ -42,7 +42,7 @@ public class AnalyticsHttpClientBuilderServiceImpl implements AnalyticsHttpClien
     }
 
     public Client newDefaultClientInstance() {
-        if (isHostnameVerifierEnabled) {
+        if (!isHostnameVerifierEnabled) {
             return new Client.Default(null, (hostName, sslSession) -> true);
         } else {
             return new Client.Default(null, null);

--- a/pom.xml
+++ b/pom.xml
@@ -763,7 +763,7 @@
         <osgi.framework.import.version.range>[1.8.0, 2.0.0)</osgi.framework.import.version.range>
         <osgi.service.tracker.import.version.range>[1.5.1, 2.0.0)</osgi.service.tracker.import.version.range>
         <carbon.kernel.version>5.2.6</carbon.kernel.version>
-        <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
+        <carbon.kernel.package.import.version.range>[5.2.6, 6.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.pax.version>5.2.6</carbon.kernel.pax.version>
         <slf4j.version>1.7.12</slf4j.version>
         <slf4j.version.range>[1.7,2)</slf4j.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -762,9 +762,9 @@
 
         <osgi.framework.import.version.range>[1.8.0, 2.0.0)</osgi.framework.import.version.range>
         <osgi.service.tracker.import.version.range>[1.5.1, 2.0.0)</osgi.service.tracker.import.version.range>
-        <carbon.kernel.version>5.2.2</carbon.kernel.version>
+        <carbon.kernel.version>5.2.6-SNAPSHOT</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.kernel.pax.version>5.2.2</carbon.kernel.pax.version>
+        <carbon.kernel.pax.version>5.2.6-SNAPSHOT</carbon.kernel.pax.version>
         <slf4j.version>1.7.12</slf4j.version>
         <slf4j.version.range>[1.7,2)</slf4j.version.range>
         <disruptor.version>3.3.2.wso2v2</disruptor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -762,9 +762,9 @@
 
         <osgi.framework.import.version.range>[1.8.0, 2.0.0)</osgi.framework.import.version.range>
         <osgi.service.tracker.import.version.range>[1.5.1, 2.0.0)</osgi.service.tracker.import.version.range>
-        <carbon.kernel.version>5.2.6-SNAPSHOT</carbon.kernel.version>
+        <carbon.kernel.version>5.2.6</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.kernel.pax.version>5.2.6-SNAPSHOT</carbon.kernel.pax.version>
+        <carbon.kernel.pax.version>5.2.6</carbon.kernel.pax.version>
         <slf4j.version>1.7.12</slf4j.version>
         <slf4j.version.range>[1.7,2)</slf4j.version.range>
         <disruptor.version>3.3.2.wso2v2</disruptor.version>


### PR DESCRIPTION
## Purpose
Creating a HTTP Client whose behavior is by default to ignore the hostname verification, but if the hostname verification is enabled, it will create a Feign client which will verify the host.

## Goals
Making it easy to create a Client to make HTTP connections using Feign clients

## Approach
Expose AnalyticsClientBuilderService as a osgi service which can create a Client to make HTTP connections. This client is created using fiegn client.