### PR TITLE
Fixing sessionId and refreshId being regenerated

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/local/LocalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/local/LocalIdPClient.java
@@ -116,8 +116,6 @@ public class LocalIdPClient implements IdPClient {
                     LocalSession oldSession = this.usersToSessionMap.get(userValue);
                     if (oldSession != null) {
                         ZonedDateTime createdAt = ZonedDateTime.now();
-                        oldSession.setSessionId(UUID.randomUUID());
-                        oldSession.setRefreshId(UUID.randomUUID());
                         oldSession.setExpiryTime(createdAt.plusSeconds(this.sessionTimeout));
                         oldSession.setRefreshExpiryTime(createdAt.plusSeconds(this.refreshTimeout));
 


### PR DESCRIPTION
## Purpose
Fixing sessionId and refreshId being regenerated in login request

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes