### PR TITLE
Fix for DAS-621 provided by Nirmal

### DIFF
--- a/components/event-processor-manager/org.wso2.carbon.event.processor.manager.commons/src/main/java/org/wso2/carbon/event/processor/manager/commons/transport/client/TCPEventPublisher.java
+++ b/components/event-processor-manager/org.wso2.carbon.event.processor.manager.commons/src/main/java/org/wso2/carbon/event/processor/manager/commons/transport/client/TCPEventPublisher.java
@@ -21,7 +21,9 @@ package org.wso2.carbon.event.processor.manager.commons.transport.client;
 import com.lmax.disruptor.EventFactory;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.RingBuffer;
+import com.lmax.disruptor.TimeoutBlockingWaitStrategy;
 import com.lmax.disruptor.dsl.Disruptor;
+import com.lmax.disruptor.dsl.ProducerType;
 import org.apache.log4j.Logger;
 import org.wso2.carbon.event.processor.manager.commons.transport.common.EventServerUtils;
 import org.wso2.carbon.event.processor.manager.commons.transport.common.StreamRuntimeInfo;
@@ -39,6 +41,7 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.*;
+import java.util.concurrent.TimeUnit;
 
 public class TCPEventPublisher {
     public static final int PING_HEADER_VALUE = -99;
@@ -312,7 +315,8 @@ public class TCPEventPublisher {
             public ByteArrayHolder newInstance() {
                 return new ByteArrayHolder();
             }
-        }, publisherConfig.getBufferSize(), Executors.newSingleThreadExecutor());
+        }, publisherConfig.getBufferSize(), Executors.newCachedThreadPool(), ProducerType.MULTI, new
+                TimeoutBlockingWaitStrategy(1, TimeUnit.SECONDS));
 
         this.ringBuffer = disruptor.getRingBuffer();
 

--- a/components/event-receiver/org.wso2.carbon.event.receiver.core/src/main/java/org/wso2/carbon/event/receiver/core/internal/management/BlockingEventQueue.java
+++ b/components/event-receiver/org.wso2.carbon.event.receiver.core/src/main/java/org/wso2/carbon/event/receiver/core/internal/management/BlockingEventQueue.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.event.receiver.core.internal.util.EventReceiverUtil;
 import java.io.Serializable;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -62,7 +63,7 @@ public class BlockingEventQueue implements Serializable {
             this.currentEventSize = EventReceiverUtil.getSize(event) + 4; //for the int value for size field.
             while (currentSize.get() >= maxSizeInBytes) {
                 // waits if the queue has exceeded the max size
-                notFull.await();
+                notFull.await(30, TimeUnit.SECONDS);
             }
             this.queue.put(new WrappedEvent(this.currentEventSize, event));
             c = currentSize.getAndAdd(this.currentEventSize);
@@ -90,7 +91,7 @@ public class BlockingEventQueue implements Serializable {
         try {
             while (currentSize.get() == 0) {
                 // waits if the queue is empty
-                notEmpty.await();
+                notEmpty.await(30, TimeUnit.SECONDS);
             }
             wrappedEvent = this.queue.take();
             c = currentSize.getAndAdd(-wrappedEvent.getSize());


### PR DESCRIPTION
## Purpose
> Introduces TimeoutBlockingWaitStrategy for disruptor used for Internal event syncing purposes. This is in order to handle a rare occurrence where a wake-up signal is lost, and to avoid using infinite blocking.