### PR TITLE
Reduce INFO log noise

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/internal/IdPClientServiceComponent.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/internal/IdPClientServiceComponent.java
@@ -63,12 +63,13 @@ public class IdPClientServiceComponent implements RequiredCapabilityListener {
 
     @Activate
     protected void start(BundleContext bundleContext) {
+        LOG.debug("IdPClient service component is activated.");
         this.bundleContext = bundleContext;
     }
 
     @Deactivate
     protected void stop() {
-        LOG.info("IdPClient Component is deactivated...");
+        LOG.debug("IdPClient service component is deactivated.");
         if (this.idpClientRegistrationService != null) {
             idpClientRegistrationService.unregister();
         }
@@ -110,7 +111,7 @@ public class IdPClientServiceComponent implements RequiredCapabilityListener {
 
     @Override
     public void onAllRequiredCapabilitiesAvailable() {
-        LOG.info("IdPClientServiceComponent is activated...");
+        LOG.debug("IdPClient service component is started.");
         try {
             IdPClient idPClient = IdPServiceUtils.getIdPClient(configProvider, idPClientFactoryHashMap);
             this.idpClientRegistrationService =

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientFactory.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientFactory.java
@@ -59,13 +59,12 @@ public class ExternalIdPClientFactory implements IdPClientFactory {
 
     @Activate
     protected void activate(BundleContext bundleContext) {
-        if (LOG.isDebugEnabled()) {
-            LOG.info("External IdP Client factory registered...");
-        }
+        LOG.debug("External IDP client factory activated.");
     }
 
     @Deactivate
     protected void deactivate(BundleContext bundleContext) {
+        LOG.debug("External IDP client factory deactivated.");
     }
 
     /**

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/local/LocalIdPClientFactory.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/local/LocalIdPClientFactory.java
@@ -49,13 +49,12 @@ public class LocalIdPClientFactory implements IdPClientFactory {
 
     @Activate
     protected void activate(BundleContext bundleContext) {
-        if (LOG.isDebugEnabled()) {
-            LOG.info("Local User Store Factory registered...");
-        }
+        LOG.debug("Local IDP client factory activated.");
     }
 
     @Deactivate
     protected void deactivate(BundleContext bundleContext) {
+        LOG.debug("Local IDP client factory deactivated.");
     }
 
     @Override


### PR DESCRIPTION
## Purpose
Due to unnecessary INFO level logs, the terminal gets cluttered at the server startup.

## Goals
- Reduce INFO logs at server startup.

## Approach
- Change log level to DEBUG

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
