### PR TITLE
Bump MSF4J version to v2.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -805,8 +805,8 @@
         <carbon.messaging.version>3.0.1</carbon.messaging.version>
         <carbon.messaging.package.import.version.range>[0.0.0, 4.0.0)</carbon.messaging.package.import.version.range>
 
-        <msf4j.version>2.4.1</msf4j.version>
-        <msf4j.import.version.range>[2.0.0, 3.0.0)</msf4j.import.version.range>
+        <msf4j.version>2.5.2</msf4j.version>
+        <msf4j.import.version.range>[2.5.0, 3.0.0)</msf4j.import.version.range>
 
         <com.fasterxml.jackson.core.version>2.7.4</com.fasterxml.jackson.core.version>
         <io.swagger.version>1.5.10</io.swagger.version>


### PR DESCRIPTION
## Purpose
Bumps MSF4J version to v2.5.2

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
