### PR TITLE
Add configuration to disable permission

### DIFF
--- a/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/bean/PermissionConfig.java
+++ b/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/bean/PermissionConfig.java
@@ -39,6 +39,9 @@ public class PermissionConfig {
     @Element(description = "Permission provider datasource name")
     private String datasourceName = "WSO2_PERMISSIONS_DB";
 
+    @Element(description = "Boolean for permission provider enable or disable")
+    private boolean isPermissionDisabled = false;
+
     @Element(description = "Database queries template array list.")
     List<Queries> queries = new ArrayList<>();
 
@@ -85,5 +88,23 @@ public class PermissionConfig {
      */
     public List<Queries> getQueries() {
         return queries;
+    }
+
+    /**
+     * set permission disabled flag.
+     *
+     * @return isPemissionDisabled
+     */
+    public boolean isPermissionDisabled() {
+        return isPermissionDisabled;
+    }
+
+    /**
+     * get permission disabled flag.
+     *
+     * @param isPermissionDisabled
+     */
+    public void setPermissionDisabled(boolean isPermissionDisabled) {
+        this.isPermissionDisabled = isPermissionDisabled;
     }
 }

--- a/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/internal/impl/DefaultPermissionProvider.java
+++ b/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/internal/impl/DefaultPermissionProvider.java
@@ -204,6 +204,11 @@ public class DefaultPermissionProvider implements PermissionProvider {
         if (log.isDebugEnabled()) {
             log.debug("Check permission " + permission);
         }
+
+        if (permissionConfig.isPermissionDisabled()) {
+            return true;
+        }
+
         List<Role> roles = getRoles(username);
         org.wso2.carbon.analytics.idp.client.core.models.Role adminRole;
         try {


### PR DESCRIPTION
## Purpose
> This PR will add configuration to disable permission in Default permission provider.

## Goals
> add configuration to disable permission in Default permission provider.


## Approach
> Add configuration in deployment yaml to disable the permission model for REST APIs

## User stories
> NA

## Release note
> NA

## Documentation
> NA

## Training
> NA

## Certification
> Na

## Marketing
> Na

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> NA

## Related PRs
> NA

## Migrations (if applicable)
> NA
 
## Learning
> NA