### PR TITLE
Fixes https://github.com/wso2/product-apim/issues/2626

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
@@ -280,16 +280,16 @@ public abstract class DataEndpoint {
                     log.error("Unable to process this event.", ex);
                 } catch (Exception ex) {
                     log.error("Unexpected error occurred while sending the event. ", ex);
-                    handleFailedEvents();
+                    handleFailedEvents(this.events);
                 }
             } catch (DataEndpointException e) {
                 log.error("Unable to send events to the endpoint. ", e);
-                handleFailedEvents();
+                handleFailedEvents(this.events);
             } catch (UndefinedEventTypeException e) {
                 log.error("Unable to process this event.", e);
             } catch (Exception ex) {
                 log.error("Unexpected error occurred while sending the event. ", ex);
-                handleFailedEvents();
+                handleFailedEvents(this.events);
             } catch (Throwable t) {
                 //There can be situations where runtime exceptions/class not found exceptions occur, This block help to catch those exceptions.
                 //No need to retry send events. Deactivating the state would be enough.
@@ -308,11 +308,6 @@ public abstract class DataEndpoint {
             }
         }
 
-        private void handleFailedEvents() {
-            deactivate();
-            dataEndpointFailureCallback.tryResendEvents(events);
-        }
-
         private void publish() throws DataEndpointException, SessionTimeoutException, UndefinedEventTypeException {
             Object client = getClient();
             try {
@@ -321,6 +316,11 @@ public abstract class DataEndpoint {
                 returnClient(client);
             }
         }
+    }
+
+    private void handleFailedEvents(List<Event> events) {
+        deactivate();
+        dataEndpointFailureCallback.tryResendEvents(events, this);
     }
 
     boolean isConnected() {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointFailureCallback.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointFailureCallback.java
@@ -33,6 +33,6 @@ public interface DataEndpointFailureCallback {
      * @param events List failed events
      *
      */
-    public void tryResendEvents(List<Event> events);
+    public void tryResendEvents(List<Event> events, DataEndpoint failedEP);
 
 }


### PR DESCRIPTION
## Purpose
Purpose is fixing the issue that happens in an environment where multiple receivers are in place. So this issue can occur when the publishing fails to a selected endpoint and tries to resend the event to another active analytics endpoint if it's available. At this point, it acquires another semaphore lock while already holding the previous lock and without releasing that lock. This phenomenon will cause the publishing to stop

## Goals
Fixing https://github.com/wso2/product-apim/issues/2626