### PR TITLE
Adding html encoding for event stream add/edit/list pages

### DIFF
--- a/components/event-stream/org.wso2.carbon.event.stream.ui/pom.xml
+++ b/components/event-stream/org.wso2.carbon.event.stream.ui/pom.xml
@@ -54,6 +54,10 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/event-stream/org.wso2.carbon.event.stream.ui/src/main/resources/web/eventstream/add_event_stream_ajaxprocessor.jsp
+++ b/components/event-stream/org.wso2.carbon.event.stream.ui/src/main/resources/web/eventstream/add_event_stream_ajaxprocessor.jsp
@@ -21,6 +21,7 @@
 <%@ page import="org.wso2.carbon.event.stream.ui.EventStreamUIUtils" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.List" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <%
 
@@ -154,7 +155,7 @@
         msg = "true";
 
     } catch (Exception e) {
-        msg = e.getMessage();
+        msg = Encode.forHtmlContent(e.getMessage());
     }
 %>
 <%=msg%>

--- a/components/event-stream/org.wso2.carbon.event.stream.ui/src/main/resources/web/eventstream/edit_event_stream.jsp
+++ b/components/event-stream/org.wso2.carbon.event.stream.ui/src/main/resources/web/eventstream/edit_event_stream.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://wso2.org/projects/carbon/taglibs/carbontags.jar" prefix="carbon" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <fmt:bundle basename="org.wso2.carbon.event.stream.ui.i18n.Resources">
 
@@ -189,7 +190,7 @@
 
                                                                         %>
                                                                         <tr>
-                                                                            <td class="property-names"><%=metaData.getAttributeName()%>
+                                                                            <td class="property-names"><%=Encode.forHtmlContent(metaData.getAttributeName())%>
                                                                             </td>
                                                                             <td class="property-names"><%=metaData.getAttributeType()%>
                                                                             </td>

--- a/components/event-stream/org.wso2.carbon.event.stream.ui/src/main/resources/web/eventstream/eventStreamDetails.jsp
+++ b/components/event-stream/org.wso2.carbon.event.stream.ui/src/main/resources/web/eventstream/eventStreamDetails.jsp
@@ -27,6 +27,7 @@
            prefix="carbon" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <fmt:bundle
         basename="org.wso2.carbon.event.stream.ui.i18n.Resources">
@@ -309,7 +310,7 @@
                                                                 for (EventStreamAttributeDto metaData : streamDefinitionDto.getMetaData()) {
                                                             %>
                                                             <tr>
-                                                                <td class="property-names"><%=metaData.getAttributeName()%>
+                                                                <td class="property-names"><%=Encode.forHtmlContent(metaData.getAttributeName())%>
                                                                 </td>
                                                                 <td class="property-names"><%=metaData.getAttributeType()%>
                                                                 </td>

--- a/components/event-stream/org.wso2.carbon.event.stream.ui/src/main/resources/web/eventstream/index.jsp
+++ b/components/event-stream/org.wso2.carbon.event.stream.ui/src/main/resources/web/eventstream/index.jsp
@@ -23,6 +23,7 @@
 <%@ page import="org.wso2.carbon.event.stream.stub.EventStreamAdminServiceStub" %>
 <%@ page import="org.wso2.carbon.event.stream.stub.types.EventStreamInfoDto" %>
 <%@ page import="org.wso2.carbon.event.stream.ui.EventStreamUIUtils" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <fmt:bundle basename="org.wso2.carbon.event.stream.ui.i18n.Resources">
 
@@ -118,7 +119,7 @@
                         <a href="eventStreamDetails.jsp?ordinal=1&eventStreamWithVersion=<%=eventStreamWithVersion%>"><%=eventStreamWithVersion%>
                         </a>
                     </td>
-                    <td><%= eventStreamInfoDto.getStreamDescription() != null ? eventStreamInfoDto.getStreamDescription() : "" %>
+                    <td><%= eventStreamInfoDto.getStreamDescription() != null ? Encode.forHtmlContent(eventStreamInfoDto.getStreamDescription()) : "" %>
                     </td>
                     <td>
 


### PR DESCRIPTION
## Purpose
- Adding html encoding for event stream description in event stream list page
- Adding html encoding for event stream metadata attribute name, into event stream edit/view jsp pages
- Adding html encoding for event stream creation failure error messages


## Related PRs
> None

## Migrations (if applicable)
> Not Required

## Test environment
> JDK 1.8.x
