### PR TITLE
Fix for the issue in Queue input event dispatchers

### DIFF
--- a/components/event-processor-manager/org.wso2.carbon.event.processor.manager.commons/src/main/java/org/wso2/carbon/event/processor/manager/commons/transport/client/TCPEventPublisher.java
+++ b/components/event-processor-manager/org.wso2.carbon.event.processor.manager.commons/src/main/java/org/wso2/carbon/event/processor/manager/commons/transport/client/TCPEventPublisher.java
@@ -168,8 +168,8 @@ public class TCPEventPublisher {
         int arbitraryMapSize = 0;
         if (hasArbitraryAttributes) {
             for (Map.Entry<String, String> entry : arbitraryMap.entrySet()) {
-                arbitraryMapSize += 4 + entry.getKey().length();
-                arbitraryMapSize += 4 + entry.getValue().length();
+                arbitraryMapSize += 4 + entry.getKey().getBytes(defaultCharset).length;
+                arbitraryMapSize += 4 + entry.getValue().getBytes(defaultCharset).length;
             }
         }
         ByteBuffer buf = ByteBuffer.allocate(streamRuntimeInfo.getFixedMessageSize() + streamIdSize + 16);

--- a/components/event-receiver/org.wso2.carbon.event.receiver.core/src/main/java/org/wso2/carbon/event/receiver/core/internal/management/QueueInputEventDispatcher.java
+++ b/components/event-receiver/org.wso2.carbon.event.receiver.core/src/main/java/org/wso2/carbon/event/receiver/core/internal/management/QueueInputEventDispatcher.java
@@ -104,7 +104,7 @@ public class QueueInputEventDispatcher extends AbstractInputEventDispatcher impl
 
     @Override
     public void process(Event event) {
-        if(isContinueProcess()){
+        if (isContinueProcess()) {
             readLock.lock();
             readLock.unlock();
             callBack.sendEvent(event);
@@ -190,7 +190,7 @@ public class QueueInputEventDispatcher extends AbstractInputEventDispatcher impl
                         Event event = eventQueue.take();
                         readLock.lock();
                         readLock.unlock();
-                        if(isContinueProcess()){
+                        if (isContinueProcess()) {
                             callBack.sendEvent(event);
                         }
                         if (isSendToOther()) {
@@ -198,6 +198,9 @@ public class QueueInputEventDispatcher extends AbstractInputEventDispatcher impl
                         }
                     } catch (InterruptedException e) {
                         log.error("Interrupted while waiting to get an event from queue.", e);
+                    } catch (Throwable t) {
+                        log.error("Error has occured while waiting to get an event from the queue which is " +
+                                "belonging to tenentId:" + tenantId + " and Stream Definition: " + streamDefinition, t);
                     }
                 }
             } catch (Exception e) {


### PR DESCRIPTION
## Purpose
Queue input event dispatchers can exist execution causing data blockage in the entire server.
The relevant issue which is created in - https://github.com/wso2/carbon-analytics-common/issues/552