### PR TITLE
Add capability to start and stop databridge servers on demand

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.commons/src/main/java/org/wso2/carbon/databridge/commons/ServerEventListener.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.commons/src/main/java/org/wso2/carbon/databridge/commons/ServerEventListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.databridge.commons;
+
+/**
+ * Parent interface of handling servers. This extension point can be used to implement databridge server
+ * handling
+ */
+public interface ServerEventListener {
+
+    void start();
+
+    void stop();
+
+}
+
+

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/DataBridgeDS.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/DataBridgeDS.java
@@ -82,8 +82,6 @@ public class DataBridgeDS {
                 dataBridgeEventStreamServiceRegistration = bundleContext.
                         registerService(DataBridgeStreamStore.class.getName(),
                                 new DataBridgeStreamStore(), null);
-
-                log.info("Successfully deployed Agent Server ");
             }
         } catch (RuntimeException e) {
             log.error("Error in starting Agent Server ", e);
@@ -162,3 +160,4 @@ public class DataBridgeDS {
     }
 
 }
+

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/internal/BinaryDataReceiver.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/internal/BinaryDataReceiver.java
@@ -1,24 +1,25 @@
 /*
-*  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.databridge.receiver.binary.internal;
 
 import org.apache.log4j.Logger;
+import org.wso2.carbon.databridge.commons.ServerEventListener;
 import org.wso2.carbon.databridge.commons.binary.BinaryMessageConstants;
 import org.wso2.carbon.databridge.core.DataBridgeReceiverService;
 import org.wso2.carbon.databridge.core.exception.DataBridgeException;
@@ -52,12 +53,13 @@ import static org.wso2.carbon.databridge.commons.binary.BinaryMessageConverterUt
 /**
  * Binary Transport Receiver implementation.
  */
-public class BinaryDataReceiver {
+public class BinaryDataReceiver implements ServerEventListener {
     private static final Logger log = Logger.getLogger(BinaryDataReceiver.class);
     private DataBridgeReceiverService dataBridgeReceiverService;
     private BinaryDataReceiverConfiguration binaryDataReceiverConfiguration;
     private ExecutorService sslReceiverExecutorService;
     private ExecutorService tcpReceiverExecutorService;
+    private static final String DISABLE_RECEIVER = "disable.receiver";
 
     public BinaryDataReceiver(BinaryDataReceiverConfiguration binaryDataReceiverConfiguration,
                               DataBridgeReceiverService dataBridgeReceiverService) {
@@ -69,11 +71,24 @@ public class BinaryDataReceiver {
                 getSizeOfTCPThreadPool(), "Receiver-Binary-TCP");
     }
 
-    public void start() throws IOException, DataBridgeException {
-        startSecureTransmission();
-        startEventTransmission();
+    @Override
+    public void start() {
+        String disableReceiver = System.getProperty(DISABLE_RECEIVER);
+        if (disableReceiver != null && Boolean.parseBoolean(disableReceiver)) {
+            log.info("Receiver disabled.");
+            return;
+        }
+        try {
+            startSecureTransmission();
+            startEventTransmission();
+        } catch (IOException e) {
+            log.error("Error while starting binary data receiver ", e);
+        } catch (DataBridgeException e) {
+            log.error("Error while starting binary data receiver ", e);
+        }
     }
 
+    @Override
     public void stop() {
         log.info("Stopping Binary Server..");
         sslReceiverExecutorService.shutdown();
@@ -322,3 +337,4 @@ public class BinaryDataReceiver {
         }
     }
 }
+

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/internal/BinaryDataReceiver.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/internal/BinaryDataReceiver.java
@@ -60,6 +60,7 @@ public class BinaryDataReceiver implements ServerEventListener {
     private ExecutorService sslReceiverExecutorService;
     private ExecutorService tcpReceiverExecutorService;
     private static final String DISABLE_RECEIVER = "disable.receiver";
+    private boolean isStarted = false;
 
     public BinaryDataReceiver(BinaryDataReceiverConfiguration binaryDataReceiverConfiguration,
                               DataBridgeReceiverService dataBridgeReceiverService) {
@@ -74,13 +75,14 @@ public class BinaryDataReceiver implements ServerEventListener {
     @Override
     public void start() {
         String disableReceiver = System.getProperty(DISABLE_RECEIVER);
-        if (disableReceiver != null && Boolean.parseBoolean(disableReceiver)) {
+        if (Boolean.parseBoolean(disableReceiver)) {
             log.info("Receiver disabled.");
             return;
         }
         try {
             startSecureTransmission();
             startEventTransmission();
+            isStarted = true;
         } catch (IOException e) {
             log.error("Error while starting binary data receiver ", e);
         } catch (DataBridgeException e) {
@@ -90,9 +92,14 @@ public class BinaryDataReceiver implements ServerEventListener {
 
     @Override
     public void stop() {
-        log.info("Stopping Binary Server..");
-        sslReceiverExecutorService.shutdown();
-        tcpReceiverExecutorService.shutdown();
+        if (isStarted) {
+            log.info("Stopping Binary Server..");
+            sslReceiverExecutorService.shutdown();
+            tcpReceiverExecutorService.shutdown();
+        } else {
+            log.info("Binary server not started in order to stop");
+        }
+
     }
 
     private void startSecureTransmission() throws IOException, DataBridgeException {

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/internal/BinaryDataReceiverServiceComponent.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/internal/BinaryDataReceiverServiceComponent.java
@@ -1,20 +1,20 @@
 /*
-*  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.databridge.receiver.binary.internal;
 
 import org.apache.log4j.Logger;
@@ -23,12 +23,10 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.databridge.commons.ServerEventListener;
 import org.wso2.carbon.databridge.core.DataBridgeReceiverService;
-import org.wso2.carbon.databridge.core.exception.DataBridgeException;
 import org.wso2.carbon.databridge.receiver.binary.conf.BinaryDataReceiverConfiguration;
 import org.wso2.carbon.kernel.CarbonRuntime;
-
-import java.io.IOException;
 
 /**
  * Binary Data Receiver ServiceComponent.
@@ -42,7 +40,6 @@ public class BinaryDataReceiverServiceComponent {
     private static final Logger log = Logger.getLogger(BinaryDataReceiverServiceComponent.class);
     private DataBridgeReceiverService dataBridgeReceiverService;
     private static CarbonRuntime carbonRuntime;
-    private static final String DISABLE_RECEIVER = "disable.receiver";
     private BinaryDataReceiver binaryDataReceiver;
 
     /**
@@ -51,20 +48,11 @@ public class BinaryDataReceiverServiceComponent {
      * @param context
      */
     protected void activate(ComponentContext context) {
-        String disableReceiver = System.getProperty(DISABLE_RECEIVER);
-        if (disableReceiver != null && Boolean.parseBoolean(disableReceiver)) {
-            log.info("Receiver disabled.");
-            return;
-        }
+        log.info("org.wso2.carbon.databridge.receiver.binary.internal.Service Component is activated");
         binaryDataReceiver = new BinaryDataReceiver(new BinaryDataReceiverConfiguration(dataBridgeReceiverService.
                 getInitialConfig()), dataBridgeReceiverService);
-        try {
-            binaryDataReceiver.start();
-        } catch (IOException e) {
-            log.error("Error while starting binary data receiver ", e);
-        } catch (DataBridgeException e) {
-            log.error("Error while starting binary data receiver ", e);
-        }
+        context.getBundleContext().registerService(ServerEventListener.class.getName(),
+                binaryDataReceiver, null);
     }
 
     protected void deactivate(ComponentContext context) {
@@ -106,4 +94,6 @@ public class BinaryDataReceiverServiceComponent {
     public static CarbonRuntime getCarbonRuntime() {
         return carbonRuntime;
     }
+
 }
+

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/ThriftDataReceiverDS.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/ThriftDataReceiverDS.java
@@ -25,6 +25,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.databridge.commons.ServerEventListener;
 import org.wso2.carbon.databridge.core.DataBridgeReceiverService;
 import org.wso2.carbon.kernel.CarbonRuntime;
 
@@ -40,8 +41,7 @@ import org.wso2.carbon.kernel.CarbonRuntime;
 
 public class ThriftDataReceiverDS {
     private static final Logger log = Logger.getLogger(ThriftDataReceiverDS.class);
-
-    private static final String DISABLE_RECEIVER = "disable.receiver";
+    private ThriftServerStartupImpl thriftServerStartup;
 
     /**
      * This is the activation method of ThriftDataReceiverDS. This will be called when its references are
@@ -52,13 +52,9 @@ public class ThriftDataReceiverDS {
      */
     @Activate
     protected void start(BundleContext bundleContext) throws Exception {
-        String disableReceiver = System.getProperty(DISABLE_RECEIVER);
-        if (disableReceiver != null && Boolean.parseBoolean(disableReceiver)) {
-            log.info("Receiver disabled.");
-            return;
-        }
-        // Register ThriftServerStartupImpl instance as an OSGi service.
-        new ThriftServerStartupImpl().completingServerStartup();
+        log.info("Service Component is activated");
+        bundleContext.registerService(ServerEventListener.class.getName(),
+                new ThriftServerStartupImpl(), null);
     }
 
     /**
@@ -69,12 +65,7 @@ public class ThriftDataReceiverDS {
      */
     @Deactivate
     protected void stop() throws Exception {
-        log.info("Thrift server shutting down...");
-
-        ServiceHolder.getDataReceiver().stop();
-        if (log.isDebugEnabled()) {
-            log.debug("Successfully stopped thrift agent server");
-        }
+        thriftServerStartup.stop();
     }
 
     /**

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/ThriftServerStartupImpl.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/ThriftServerStartupImpl.java
@@ -1,24 +1,25 @@
 /*
-*  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.databridge.receiver.thrift.internal;
 
 import org.apache.log4j.Logger;
+import org.wso2.carbon.databridge.commons.ServerEventListener;
 import org.wso2.carbon.databridge.commons.thrift.utils.HostAddressFinder;
 import org.wso2.carbon.databridge.core.exception.DataBridgeException;
 import org.wso2.carbon.databridge.receiver.thrift.ThriftDataReceiverFactory;
@@ -27,11 +28,18 @@ import org.wso2.carbon.databridge.receiver.thrift.conf.ThriftDataReceiverConfigu
 /**
  * Thrift Server Startup Implementation.
  */
-public class ThriftServerStartupImpl implements ThriftServerStartup {
+public class ThriftServerStartupImpl implements ServerEventListener {
 
     private static final Logger log = Logger.getLogger(ThriftServerStartupImpl.class);
+    private static final String DISABLE_RECEIVER = "disable.receiver";
 
-    public void completingServerStartup() {
+    @Override
+    public void start() {
+        String disableReceiver = System.getProperty(DISABLE_RECEIVER);
+        if (disableReceiver != null && Boolean.parseBoolean(disableReceiver)) {
+            log.info("Receiver disabled.");
+            return;
+        }
         try {
             ThriftDataReceiverConfiguration thriftDataReceiverConfiguration = new ThriftDataReceiverConfiguration(
                     ServiceHolder.getDataBridgeReceiverService().getInitialConfig(),
@@ -66,4 +74,15 @@ public class ThriftServerStartupImpl implements ThriftServerStartup {
             log.error("Unexpected Error in starting Agent Server ", e);
         }
     }
+
+    @Override
+    public void stop() {
+        log.info("Thrift server shutting down...");
+
+        ServiceHolder.getDataReceiver().stop();
+        if (log.isDebugEnabled()) {
+            log.debug("Successfully stopped thrift agent server");
+        }
+    }
 }
+

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/ThriftServerStartupImpl.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/ThriftServerStartupImpl.java
@@ -32,11 +32,12 @@ public class ThriftServerStartupImpl implements ServerEventListener {
 
     private static final Logger log = Logger.getLogger(ThriftServerStartupImpl.class);
     private static final String DISABLE_RECEIVER = "disable.receiver";
+    private boolean isStarted = false;
 
     @Override
     public void start() {
         String disableReceiver = System.getProperty(DISABLE_RECEIVER);
-        if (disableReceiver != null && Boolean.parseBoolean(disableReceiver)) {
+        if (Boolean.parseBoolean(disableReceiver)) {
             log.info("Receiver disabled.");
             return;
         }
@@ -65,6 +66,7 @@ public class ThriftServerStartupImpl implements ServerEventListener {
                     }*/
                 }
                 ServiceHolder.getDataReceiver().start(hostName);
+                isStarted = true;
             }
         } catch (DataBridgeException e) {
             log.error("Can not create and start Agent Server ", e);
@@ -77,11 +79,16 @@ public class ThriftServerStartupImpl implements ServerEventListener {
 
     @Override
     public void stop() {
-        log.info("Thrift server shutting down...");
+        if (isStarted) {
+            log.info("Thrift server shutting down...");
 
-        ServiceHolder.getDataReceiver().stop();
-        if (log.isDebugEnabled()) {
-            log.debug("Successfully stopped thrift agent server");
+            ServiceHolder.getDataReceiver().stop();
+            isStarted = false;
+            if (log.isDebugEnabled()) {
+                log.debug("Successfully stopped thrift agent server");
+            }
+        } else {
+            log.info("Thrift server not started in order to stop");
         }
     }
 }


### PR DESCRIPTION
## Purpose
Provide capability to start and stop databridge servers

## Goals
provide more control

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes