### PR TITLE
Fix the DEFAULT version not loading issue in QueryProvider

### DIFF
--- a/components/org.wso2.carbon.database.query.manager/src/main/java/org/wso2/carbon/database/query/manager/QueryProvider.java
+++ b/components/org.wso2.carbon.database.query.manager/src/main/java/org/wso2/carbon/database/query/manager/QueryProvider.java
@@ -56,31 +56,30 @@ public class QueryProvider {
         Map<String, String> componentConfigMap = new HashMap<>();
         Map<String, String> result = new HashMap<>();
         if (deploymentQueries != null) {
-            //populate the deployment query map for given database type and version.
+            //populate the deployment.yaml RDBMS queries map for given database type and version.
             for (Queries queries : deploymentQueries) {
-                if (queries.getType().equals(databaseType) && (queries.getVersion() == null ?
-                        databaseVersion == null : queries.getVersion().equals(databaseVersion))) {
+                String queriesType = queries.getType();
+                String queriesVersion = queries.getVersion();
+                if ((queriesType.equalsIgnoreCase(databaseType) || queriesType.equalsIgnoreCase(DEFAULT_TYPE)) &&
+                        (queriesVersion.equalsIgnoreCase(databaseVersion) ||
+                                queriesVersion.equalsIgnoreCase(DEFAULT_TYPE))) {
                     deploymentConfigMap = queries.getMappings();
+                    break;
                 }
             }
         }
         if (componentQueries != null) {
-            //populate the default and component query map for given type and version.
+            //populate the default and component RDBMS queries map for given type and version.
             for (Queries queries : componentQueries) {
-                if (queries.getType().equals(DEFAULT_TYPE)) {
+                String queriesType = queries.getType();
+                String queriesVersion = queries.getVersion();
+                if (queriesType.equalsIgnoreCase(DEFAULT_TYPE)) {
                     defaultConfigSet = queries.getMappings().keySet();
-                } else if (queries.getType().equals(databaseType) && (queries.getVersion() == null ?
-                        databaseVersion == null : queries.getVersion().equals(databaseVersion))) {
+                } else if (queriesType.equalsIgnoreCase(databaseType)
+                        && (queriesVersion.equalsIgnoreCase(databaseVersion) ||
+                        queriesVersion.equalsIgnoreCase(DEFAULT_TYPE))) {
                     componentConfigMap = queries.getMappings();
-                }
-            }
-            //if matching database type and version not found check whether default version available.
-            if (componentConfigMap == null || componentConfigMap.isEmpty()) {
-                for (Queries queries : componentQueries) {
-                    if (queries.getType().equals(databaseType) && queries.getVersion() != null &&
-                            queries.getVersion().equals(DEFAULT_TYPE)) {
-                        componentConfigMap = queries.getMappings();
-                    }
+                    break;
                 }
             }
         } else {


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to fix the database default version loading issue. The current approach overrides the query template in the component if query template map entry in the deployment.yaml has an exact version. With the fixes, a user can give the query mapping as follows and it will override the default template without exact matching the database version. In addition to that matching the entries with equalsIgnoreCase.

```
wso2.rdbms.data.provider:
  queries:
    -
     mappings:
      record_delete: "DELETE dsdFROM {{TABLE_NAME}} WHERE {{INCREMENTAL_COLUMN}} in (SELECT TOP {{LIMIT_VALUE}} {{INCREMENTAL_COLUMN}} FROM {{TABLE_NAME}} ORDER BY {{INCREMENTAL_COLUMN}} ASC)"
      total_record_count: "SELECTdsd COUNT(*) FROM {{TABLE_NAME}}"
      record_limit: "SELECTdsd TOP {{LIMIT_VALUE}} * FROM ({{CUSTOM_QUERY}}) A_TABLE ORDER BY {{INCREMENTAL_COLUMN}} DESC"
      record_greater_than: "SELECTdds * FROM ({{CUSTOM_QUERY}}) A_TABLE WHERE {{INCREMENTAL_COLUMN}} > {{LAST_RECORD_VALUE}} ORDER BY {{INCREMENTAL_COLUMN}} DESC"
     type: MySQL
     version: default
```
## Goals
> Fixes introduce to resolve the problems described above

## Approach
> In the deployment configuration loading logic, matching the DEFAULT version. 

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Integration tests
   > Has integration test in carbon-analytics/module/osgi-integration

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 1.8
 
## Learning
> N/A