### PR TITLE
Slightly increased the default value of the data-bridge max worker threads from 20 to 250.

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/utils/ThriftDataReceiverConstants.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/utils/ThriftDataReceiverConstants.java
@@ -48,8 +48,8 @@ public final class ThriftDataReceiverConstants {
     public static final String THRIFT_SSL_REQUEST_TIMEOUT = "sslRequestTimeout";
     public static final String THRIFT_SSL_STOP_TIMEOUT_VAL = "sslStopTimeoutVal";
 
-    public static final int THRIFT_TCP_DEFAULT_MAX_WORKER_THREADS = 20;
-    public static final int THRIFT_SSL_DEFAULT_MAX_WORKER_THREADS = 20;
+    public static final int THRIFT_TCP_DEFAULT_MAX_WORKER_THREADS = 40;
+    public static final int THRIFT_SSL_DEFAULT_MAX_WORKER_THREADS = 40;
 
     public static final int UNDEFINED = -1;
 }

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/utils/ThriftDataReceiverConstants.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/utils/ThriftDataReceiverConstants.java
@@ -48,8 +48,8 @@ public final class ThriftDataReceiverConstants {
     public static final String THRIFT_SSL_REQUEST_TIMEOUT = "sslRequestTimeout";
     public static final String THRIFT_SSL_STOP_TIMEOUT_VAL = "sslStopTimeoutVal";
 
-    public static final int THRIFT_TCP_DEFAULT_MAX_WORKER_THREADS = 250;
-    public static final int THRIFT_SSL_DEFAULT_MAX_WORKER_THREADS = 250;
+    public static final int THRIFT_TCP_DEFAULT_MAX_WORKER_THREADS = 1000;
+    public static final int THRIFT_SSL_DEFAULT_MAX_WORKER_THREADS = 1000;
 
     public static final int UNDEFINED = -1;
 }

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/utils/ThriftDataReceiverConstants.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/utils/ThriftDataReceiverConstants.java
@@ -48,8 +48,8 @@ public final class ThriftDataReceiverConstants {
     public static final String THRIFT_SSL_REQUEST_TIMEOUT = "sslRequestTimeout";
     public static final String THRIFT_SSL_STOP_TIMEOUT_VAL = "sslStopTimeoutVal";
 
-    public static final int THRIFT_TCP_DEFAULT_MAX_WORKER_THREADS = 40;
-    public static final int THRIFT_SSL_DEFAULT_MAX_WORKER_THREADS = 40;
+    public static final int THRIFT_TCP_DEFAULT_MAX_WORKER_THREADS = 250;
+    public static final int THRIFT_SSL_DEFAULT_MAX_WORKER_THREADS = 250;
 
     public static final int UNDEFINED = -1;
 }


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/wso2/carbon-analytics-common/issues/562

## Goals
> To avoid 'WARN {org.apache.thrift.server.TThreadPoolServer} - Task has been rejected by ExecutorService'

## Approach
> Increase the default data-bridge max worker thread count. I've slightly increased the value from 20 to 250 by considering one publisher is publishing. Need to add an optimal value.


## Documentation
> If the default value is in the documentation, that needs to be updated.


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> List all JDK versions - 8, operating system- Linux, databases- Oracle 
