### PR TITLE
Validate event stream name on saving

### DIFF
--- a/components/event-stream/org.wso2.carbon.event.stream.ui/src/main/resources/web/eventstream/add_event_stream_ajaxprocessor.jsp
+++ b/components/event-stream/org.wso2.carbon.event.stream.ui/src/main/resources/web/eventstream/add_event_stream_ajaxprocessor.jsp
@@ -34,7 +34,11 @@
     try {
         EventStreamAdminServiceStub stub = EventStreamUIUtils.getEventStreamAdminService(config, session, request);
         EventStreamDefinitionDto eventStreamDefinitionDto = new EventStreamDefinitionDto();
-        eventStreamDefinitionDto.setName(request.getParameter("eventStreamName"));
+        String eventStreamName = request.getParameter("eventStreamName");
+        if (!eventStreamName.matches("^([a-z]|[A-Z]|_|\\.|-)([a-z]|[A-Z]|[0-9]|_|\\.|-)*$")) {
+            throw new Exception("Invalid event stream name.");
+        }
+        eventStreamDefinitionDto.setName(eventStreamName);
         eventStreamDefinitionDto.setVersion(request.getParameter("eventStreamVersion"));
         eventStreamDefinitionDto.setDescription(request.getParameter("eventStreamDescription"));
         eventStreamDefinitionDto.setNickName(request.getParameter("eventStreamNickName"));


### PR DESCRIPTION
## Purpose
This PR validates the name of the event stream on saving at the server side.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes