### PR TITLE
Fix issue of trying to end a tenant flow even though it is not created

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/authentication/CarbonAuthenticationHandler.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/authentication/CarbonAuthenticationHandler.java
@@ -91,14 +91,10 @@ public class CarbonAuthenticationHandler implements AuthenticationHandler {
     @Override
     public void initContext(AgentSession agentSession) {
         int tenantId = agentSession.getCredentials().getTenantId();
-        PrivilegedCarbonContext currentContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
-        if (currentContext.getTenantId(true) != tenantId) {
-            PrivilegedCarbonContext.destroyCurrentContext();
-            PrivilegedCarbonContext.startTenantFlow();
-            PrivilegedCarbonContext privilegedCarbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
-            privilegedCarbonContext.setTenantId(tenantId);
-            privilegedCarbonContext.setTenantDomain(agentSession.getDomainName());
-        }
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext privilegedCarbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+        privilegedCarbonContext.setTenantId(tenantId);
+        privilegedCarbonContext.setTenantDomain(agentSession.getDomainName());
     }
 
     @Override


### PR DESCRIPTION
## Purpose
When publishing analytics stats via SSL, an error occurs while starting the integrator server. This happens due to an error while waiting for the ack from publishing. The flow gets interrupted in analytics server because it tries to end a tenant flow even though it is not created.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes