### PR TITLE
Increase THRIFT_DEFAULT_MAX_WORKER_THREADS to 2500

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/utils/ThriftDataReceiverConstants.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/utils/ThriftDataReceiverConstants.java
@@ -48,8 +48,8 @@ public final class ThriftDataReceiverConstants {
     public static final String THRIFT_SSL_REQUEST_TIMEOUT = "sslRequestTimeout";
     public static final String THRIFT_SSL_STOP_TIMEOUT_VAL = "sslStopTimeoutVal";
 
-    public static final int THRIFT_TCP_DEFAULT_MAX_WORKER_THREADS = 1000;
-    public static final int THRIFT_SSL_DEFAULT_MAX_WORKER_THREADS = 1000;
+    public static final int THRIFT_TCP_DEFAULT_MAX_WORKER_THREADS = 2500;
+    public static final int THRIFT_SSL_DEFAULT_MAX_WORKER_THREADS = 2500;
 
     public static final int UNDEFINED = -1;
 }


### PR DESCRIPTION
## Purpose
Increase THRIFT_TCP_DEFAULT_MAX_WORKER_THREADS to 2500 

## Goals
Increase THRIFT_TCP_DEFAULT_MAX_WORKER_THREADS to 2500 

## Approach
Increase THRIFT_TCP_DEFAULT_MAX_WORKER_THREADS to 2500 

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Certification
NA

## Marketing
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
Ubuntu
Java 8
 
## Learning
NA