### PR TITLE
Fix Semaphore Leak when retrying in data bridge agent

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/EventPublisherThreadPoolExecutor.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/EventPublisherThreadPoolExecutor.java
@@ -48,17 +48,13 @@ public class EventPublisherThreadPoolExecutor extends ThreadPoolExecutor {
         super.execute(task);
     }
 
-    public void submitJobAndSetState(Thread thread, DataEndpoint dataEndpoint) {
+    public void submitJobAndSetState(DataEndpoint.EventPublisher publisher, DataEndpoint dataEndpoint) {
         int permits = semaphore.availablePermits();
         if (permits <= 1){
             dataEndpoint.setState(DataEndpoint.State.BUSY);
         }
-        submit(thread);
+        publisher.setPoolSemaphore(semaphore);
+        submit(new Thread(publisher));
     }
 
-    @Override
-    protected void afterExecute(final Runnable r, final Throwable t) {
-        super.afterExecute(r, t);
-        semaphore.release();
-    }
 }


### PR DESCRIPTION
## Purpose
$subject

## Approach
Release semaphore before retrying logic

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes