### PR TITLE
Fix Semaphore Leak when retrying in data bridge agent

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
@@ -288,7 +288,8 @@ public abstract class DataEndpoint {
                     log.error("Unexpected error occurred while sending the event. ", ex);
                     handleFailedEvents();
                 } catch (Throwable t) {
-                    //There can be situations where runtime exceptions/class not found exceptions occur, This block help to catch those exceptions.
+                    //There can be situations where runtime exceptions/class not found exceptions occur,
+                    //This block help to catch those exceptions.
                     //No need to retry send events. Deactivating the state would be enough.
                     log.error("Unexpected error occurred while sending events. ", t);
                     semaphoreRelease();

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
@@ -83,14 +83,14 @@ public abstract class DataEndpoint {
     void collectAndSend(Event event) {
         events.add(event);
         if (events.size() >= batchSize) {
-            threadPoolExecutor.submitJobAndSetState(new Thread(new EventPublisher(events)), this);
+            threadPoolExecutor.submitJobAndSetState(new EventPublisher(events), this);
             events = new ArrayList<>();
         }
     }
 
     void flushEvents() {
         if (events.size() != 0) {
-            threadPoolExecutor.submitJobAndSetState(new Thread(new EventPublisher(events)), this);
+            threadPoolExecutor.submitJobAndSetState(new EventPublisher(events), this);
             events = new ArrayList<>();
         }
     }
@@ -263,6 +263,7 @@ public abstract class DataEndpoint {
      */
     class EventPublisher implements Runnable {
         List<Event> events;
+        private Semaphore semaphore;
 
         public EventPublisher(List<Event> events) {
             this.events = events;
@@ -282,15 +283,23 @@ public abstract class DataEndpoint {
                     publish();
                 } catch (UndefinedEventTypeException ex) {
                     log.error("Unable to process this event.", ex);
+                    semaphoreRelease();
                 } catch (Exception ex) {
                     log.error("Unexpected error occurred while sending the event. ", ex);
                     handleFailedEvents();
+                } catch (Throwable t) {
+                    //There can be situations where runtime exceptions/class not found exceptions occur, This block help to catch those exceptions.
+                    //No need to retry send events. Deactivating the state would be enough.
+                    log.error("Unexpected error occurred while sending events. ", t);
+                    semaphoreRelease();
+                    deactivate();
                 }
             } catch (DataEndpointException e) {
                 log.error("Unable to send events to the endpoint. ", e);
                 handleFailedEvents();
             } catch (UndefinedEventTypeException e) {
                 log.error("Unable to process this event.", e);
+                semaphoreRelease();
             } catch (Exception ex) {
                 log.error("Unexpected error occurred while sending the event. ", ex);
                 handleFailedEvents();
@@ -299,6 +308,7 @@ public abstract class DataEndpoint {
                 // This block help to catch those exceptions.
                 //No need to retry send events. Deactivating the state would be enough.
                 log.error("Unexpected error occurred while sending events. ", t);
+                semaphoreRelease();
                 deactivate();
             } finally {
                 //If any processing error occurred the state will be changed to unavailable,
@@ -315,8 +325,13 @@ public abstract class DataEndpoint {
             }
         }
 
+        public void setPoolSemaphore(Semaphore semaphore) {
+            this.semaphore = semaphore;
+        }
+
         private void handleFailedEvents() {
             deactivate();
+            semaphoreRelease();
             dataEndpointFailureCallback.tryResendEvents(events);
         }
 
@@ -324,8 +339,15 @@ public abstract class DataEndpoint {
             Object client = getClient();
             try {
                 send(client, this.events);
+                semaphoreRelease();
             } finally {
                 returnClient(client);
+            }
+        }
+
+        private void semaphoreRelease() {
+            if (this.semaphore != null) {
+                this.semaphore.release();
             }
         }
     }

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/EventPublisherThreadPoolExecutor.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/EventPublisherThreadPoolExecutor.java
@@ -52,17 +52,13 @@ public class EventPublisherThreadPoolExecutor extends ThreadPoolExecutor {
         super.execute(task);
     }
 
-    public void submitJobAndSetState(Thread thread, DataEndpoint dataEndpoint) {
+    public void submitJobAndSetState(DataEndpoint.EventPublisher publisher, DataEndpoint dataEndpoint) {
         int permits = semaphore.availablePermits();
         if (permits <= 1) {
             dataEndpoint.setState(DataEndpoint.State.BUSY);
         }
-        submit(thread);
+        publisher.setPoolSemaphore(semaphore);
+        submit(new Thread(publisher));
     }
 
-    @Override
-    protected void afterExecute(final Runnable r, final Throwable t) {
-        super.afterExecute(r, t);
-        semaphore.release();
-    }
 }


### PR DESCRIPTION
## Purpose
$subject

## Approach
Release semaphore before retrying logic

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes