### PR TITLE
Add waiting time in data bridge binary receiver

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/BinaryDataReceiverConstants.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/BinaryDataReceiverConstants.java
@@ -42,4 +42,5 @@ public class BinaryDataReceiverConstants {
     public static final String META_DATA_FIELD = "Meta Data";
     public static final String PAYLOAD_DATA_FIELD = "Payload Data";
     public static final String CORRELATION_DATA_FIELD = "Correlation Data";
+    public static final String WAITING_TIME_IN_MILISECONDS = "waitingTimeInMilliSeconds";
 }

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/conf/BinaryDataReceiverConfiguration.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/conf/BinaryDataReceiverConfiguration.java
@@ -30,6 +30,7 @@ public class BinaryDataReceiverConfiguration {
     private int tcpPort;
     private int sizeOfSSLThreadPool;
     private int sizeOfTCPThreadPool;
+    private int waitingTimeInMilliSeconds;
     private String sslProtocols;
     private String ciphers;
 
@@ -53,6 +54,8 @@ public class BinaryDataReceiverConfiguration {
         this.sizeOfTCPThreadPool = Integer.parseInt(dataReceiver.getConfiguration(
                 BinaryDataReceiverConstants.TCP_RECEIVER_THREAD_POOL_SIZE,
                 BinaryDataReceiverConstants.DEFAULT_TCP_RECEIVER_THREAD_POOL_SIZE).toString());
+        this.waitingTimeInMilliSeconds = Integer.parseInt(dataReceiver.getConfiguration(
+                BinaryDataReceiverConstants.WAITING_TIME_IN_MILISECONDS, 0).toString());
 
         Object sslProtocolObj = dataReceiver.getConfiguration(BinaryDataReceiverConstants.SSL_RECEIVER_PROTOCOLS_CONFIG_NAME, null);
         sslProtocols =  sslProtocolObj != null ? sslProtocolObj.toString() : null;
@@ -86,5 +89,9 @@ public class BinaryDataReceiverConfiguration {
 
     public String getCiphers() {
         return ciphers;
+    }
+
+    public int getWaitingTimeInMilliSeconds() {
+        return waitingTimeInMilliSeconds;
     }
 }

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/internal/BinaryDataReceiverServiceComponent.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/internal/BinaryDataReceiverServiceComponent.java
@@ -49,8 +49,8 @@ public class BinaryDataReceiverServiceComponent {
             log.info("Receiver disabled.");
             return;
         }
-        binaryDataReceiver = new BinaryDataReceiver(new BinaryDataReceiverConfiguration(dataBridgeReceiverService.
-                getInitialConfig()), dataBridgeReceiverService);
+        binaryDataReceiver = new BinaryDataReceiver(new BinaryDataReceiverConfiguration(dataBridgeReceiverService
+                .getInitialConfig()), dataBridgeReceiverService);
         try {
             binaryDataReceiver.start();
         } catch (IOException e) {


### PR DESCRIPTION
## Purpose
When starting a server, the binary receiver starts accepting events even before the Carbon server fully started. This will results exceptions on the server startup.

## Approach
This PR introduces a new parameter (i.e. `waitingTimeInMilliSeconds`) in `data-bridge-config.xml` file to add an initial waiting time start the data bridge binary receiver.

#### data-bridge-config.xml

```xml
...
<dataReceiver name="Binary">
    <config name="tcpPort">9611</config>
    <config name="sslPort">9711</config>
    ...
    <config name="waitingTimeInMilliSeconds">60000</config>
    ...
</dataReceiver>
....
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes