### PR TITLE
Add timeout to testReceiverConnection test case

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/test/java/org.wso2.carbon.databridge.receiver.binary.test/BinaryDataReceiverTest.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/test/java/org.wso2.carbon.databridge.receiver.binary.test/BinaryDataReceiverTest.java
@@ -134,6 +134,7 @@ public class BinaryDataReceiverTest {
 
         BinaryDataReceiver binaryDataReceiver = new BinaryDataReceiver(dataReceiverConfiguration, dataBridge);
         binaryDataReceiver.start();
+        Thread.sleep(1000);
         SocketAddress tcpSockAddress = new InetSocketAddress("127.0.0.1", 9611);
         SocketAddress sslSockAddress = new InetSocketAddress("127.0.0.1", 9711);
         Socket socketTCP = new Socket();


### PR DESCRIPTION
## Purpose
This PR adds a timeout in testReceiverConnection until the servers start.tc.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes