### PR TITLE
Fix recurring exception on connecting to passive node

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
@@ -181,7 +181,8 @@ public class DataPublisher {
                             dataEndpointAgent.getAgentConfiguration().getCorePoolSize(),
                             dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
                             dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool(),
-                            dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds());
+                            dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds(),
+                            failOver);
                 } else {
                     endpointConfiguration = new DataEndpointConfiguration((String) receiverGroup[j],
                             (String) authGroup[j], username, password, dataEndpointAgent.getSecuredTransportPool(),
@@ -190,7 +191,8 @@ public class DataPublisher {
                             dataEndpointAgent.getAgentConfiguration().getCorePoolSize(),
                             dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
                             dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool(),
-                            dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds());
+                            dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds(),
+                            failOver);
                 }
                 DataEndpoint dataEndpoint = dataEndpointAgent.getNewDataEndpoint();
                 dataEndpoint.initialize(endpointConfiguration);

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/DataEndpointConfiguration.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/DataEndpointConfiguration.java
@@ -50,6 +50,8 @@ public class DataEndpointConfiguration {
 
     private long loggingControlIntervalInSeconds;
 
+    private boolean failOverEndpoint;
+
     public enum Protocol {
         TCP, SSL;
 
@@ -63,7 +65,7 @@ public class DataEndpointConfiguration {
                                      GenericKeyedObjectPool transportPool,
                                      GenericKeyedObjectPool securedTransportPool,
                                      int batchSize, int corePoolSize, int maxPoolSize, int keepAliveTimeInPool,
-                                     int loggingControlIntervalInSeconds) {
+                                     int loggingControlIntervalInSeconds, boolean failOverEndpoint) {
         this.receiverURL = receiverURL;
         this.authURL = authURL;
         this.username = username;
@@ -77,6 +79,7 @@ public class DataEndpointConfiguration {
         this.maxPoolSize = maxPoolSize;
         this.keepAliveTimeInPool = keepAliveTimeInPool;
         this.loggingControlIntervalInSeconds = (long) loggingControlIntervalInSeconds;
+        this.failOverEndpoint = failOverEndpoint;
     }
 
     public String getReceiverURL() {
@@ -143,6 +146,10 @@ public class DataEndpointConfiguration {
 
     public long getLoggingControlIntervalInSeconds() {
         return loggingControlIntervalInSeconds;
+    }
+
+    public boolean isFailOverEndpoint() {
+        return failOverEndpoint;
     }
 }
 

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointConnectionWorker.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointConnectionWorker.java
@@ -65,7 +65,12 @@ public class DataEndpointConnectionWorker implements Runnable {
                         loggingControlFlag.set(false);
                     }
                 } else {
-                    log.error("Error while trying to connect to the endpoint. " + e.getErrorMessage(), e);
+                    if (dataEndpointConfiguration.isFailOverEndpoint()) {
+                        log.info("Attempt to connect to the endpoint " +
+                                dataEndpoint.getDataEndpointConfiguration().getAuthURL() + " failed.");
+                    } else {
+                        log.error("Error while trying to connect to the endpoint. " + e.getErrorMessage(), e);
+                    }
                 }
                 dataEndpoint.deactivate();
             } catch (DataEndpointLoginException e) {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/DataBrigdeWorkerTestCase.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/DataBrigdeWorkerTestCase.java
@@ -65,7 +65,8 @@ public class DataBrigdeWorkerTestCase {
                         dataEndpointAgent.getAgentConfiguration().getCorePoolSize(),
                         dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
                         dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool(),
-                        dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds());
+                        dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds(),
+                        true);
         DataEndpoint dataEndpoint = dataEndpointAgent.getNewDataEndpoint();
         dataEndpoint.initialize(endpointConfiguration);
         dataEndpointConnectionWorker.initialize(dataEndpoint, endpointConfiguration);


### PR DESCRIPTION
## Purpose
In an HA deployment of Stream Processor, the passive node keeps its ports closed until the node become active. But when this setup is used with Data bridge agent (eg. in APIM), the agent tries to connect to both the receivers in the Stream Processor. Hence the ports are not exposed in the SP passive node, this results printing the following exception continuously at the agent.

```log
TID: [-1] [] [2018-12-07 18:03:41,353] ERROR {org.wso2.carbon.databridge.agent.endpoint.DataEndpointConnectionWorker} -  Error while trying to connect to the endpoint. Cannot borrow client for ssl://sp-node:7712 {org.wso2.carbon.databridge.agent.endpoint.DataEndpointConnectionWorker}
org.wso2.carbon.databridge.agent.exception.DataEndpointAuthenticationException: Cannot borrow client for ssl://sp-node:7712
	at org.wso2.carbon.databridge.agent.endpoint.DataEndpointConnectionWorker.connect(DataEndpointConnectionWorker.java:136)
	at org.wso2.carbon.databridge.agent.endpoint.DataEndpointConnectionWorker.run(DataEndpointConnectionWorker.java:59)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.wso2.carbon.databridge.agent.exception.DataEndpointSecurityException: Error while trying to connect to ssl://sp-node:7712
	at org.wso2.carbon.databridge.agent.endpoint.thrift.ThriftSecureClientPoolFactory.createClient(ThriftSecureClientPoolFactory.java:81)
	at org.wso2.carbon.databridge.agent.client.AbstractClientPoolFactory.makeObject(AbstractClientPoolFactory.java:39)
	at org.apache.commons.pool.impl.GenericKeyedObjectPool.borrowObject(GenericKeyedObjectPool.java:1212)
	at org.wso2.carbon.databridge.agent.endpoint.DataEndpointConnectionWorker.connect(DataEndpointConnectionWorker.java:126)
	... 6 more
    ...
```

## Goals
The exception should not be printed in the logs continuously as it is the intended behavior. 

## Approach
This PR fixes the above issue by printing an informative message instead of printing the exception with its stack trace. 

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
Refer the PR

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Java 8
 
## Learning
N/A