### PR TITLE
Add email adapter to work with jdk11

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/pom.xml
@@ -107,6 +107,8 @@
                         </Export-Package>
                         <Import-Package>
                             javax.xml.namespace; version=0.0.0,
+                            javax.activation.*; version="[0.0.0, 1.0.0)",
+                            com.sun.activation.*; version="[0.0.0, 1.0.0)"
                             *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>

--- a/components/event-receiver/event-input-adapters/org.wso2.carbon.event.input.adapter.email/pom.xml
+++ b/components/event-receiver/event-input-adapters/org.wso2.carbon.event.input.adapter.email/pom.xml
@@ -97,6 +97,8 @@
                             org.wso2.carbon.event.input.adapter.core.*,
                             !javax.xml.namespace,
                             javax.xml.namespace; version=0.0.0,
+                            javax.activation.*; version="[0.0.0, 1.0.0)",
+                            com.sun.activation.*; version="[0.0.0, 1.0.0)"
                             *;resolution:=optional,
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -1172,6 +1172,11 @@
                 <artifactId>aws-java-sdk-sqs</artifactId>
                 <version>${aws.java.sdk.sqs.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>${version.org.wso2.orbit.javax.activation}</version>
+            </dependency>
 
             <!--carbon-deployment features start-->
             <!--<dependency>-->
@@ -1591,6 +1596,7 @@
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.4</powermock.version>
         <org.jacoco.ant.version>0.7.5.201505241946</org.jacoco.ant.version>
+        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v2</version.org.wso2.orbit.javax.activation>
 
     </properties>
 


### PR DESCRIPTION
## Purpose
> javax.activation components are removed from jdk11. Need to bundle it.