### PR TITLE
Fix Stopping of thrift/binary, it will wait till queue becomes empty

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/DataBridge.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/DataBridge.java
@@ -273,6 +273,10 @@ public class DataBridge implements DataBridgeSubscriberService, DataBridgeReceiv
         }
     }
 
+    public Boolean isQueueEmpty() {
+        return eventDispatcher.isQueueEmpty();
+    }
+
     private void endTimeMeasurement(int eventsNum) {
         if (isProfileReceiver) {
             eventsReceived.addAndGet(eventsNum);

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/DataBridgeReceiverService.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/DataBridgeReceiverService.java
@@ -78,6 +78,8 @@ public interface DataBridgeReceiverService {
     public void subscribe(StreamAddRemoveListener streamAddRemoveListener);
 
     public void unsubscribe(StreamAddRemoveListener streamAddRemoveListener);
+
+    public Boolean isQueueEmpty();
 }
 
 

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/EventDispatcher.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/EventDispatcher.java
@@ -211,6 +211,10 @@ public class EventDispatcher {
         eventQueue.publish(new EventComposite(eventBundle, getStreamDefinitionHolder(), agentSession, eventConverter));
     }
 
+    public Boolean isQueueEmpty() {
+        return eventQueue.isQueueEmpty();
+    }
+
     private StreamTypeHolder getStreamDefinitionHolder() {
         if (streamTypeHolder != null) {
             if (log.isDebugEnabled()) {

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/queue/EventQueue.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/queue/EventQueue.java
@@ -64,6 +64,10 @@ public class EventQueue {
         executorService.submit(new QueueWorker(eventQueue, subscribers, rawDataSubscribers, executorService));
     }
 
+    public boolean isQueueEmpty() {
+        return eventQueue.peek() == null;
+    }
+
     @Override
     protected void finalize() throws Throwable {
         executorService.shutdown();

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.wso2.carbon.analytics-common</groupId>
     <artifactId>org.wso2.carbon.analytics-common.parent</artifactId>
     <packaging>pom</packaging>
-    <version>6.0.75-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <name>WSO2 Carbon Analytics Common - Parent</name>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.wso2.carbon.analytics-common</groupId>
     <artifactId>org.wso2.carbon.analytics-common.parent</artifactId>
     <packaging>pom</packaging>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.0.75-SNAPSHOT</version>
     <name>WSO2 Carbon Analytics Common - Parent</name>
 
     <modules>


### PR DESCRIPTION
## Purpose
When stopping thrift/binary receivers wait till queue becomes empty

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes