### PR TITLE
Add support for SSO

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/config/IdPClientConfiguration.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/config/IdPClientConfiguration.java
@@ -34,6 +34,9 @@ public class IdPClientConfiguration {
     @Element(description = "Client Type", required = true)
     private String type = "local";
 
+    @Element(description = "SSO enabled")
+    private boolean ssoEnabled = false;
+
     @Element(description = "Client properties")
     private Map<String, String> properties = new HashMap<>();
 
@@ -64,5 +67,9 @@ public class IdPClientConfiguration {
 
     public ArrayList<Queries> getQueries() {
         return queries;
+    }
+
+    public boolean isSsoEnabled() {
+        return ssoEnabled;
     }
 }

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
@@ -376,8 +376,11 @@ public class ExternalIdPClient implements IdPClient {
                 returnProperties.put(IdPClientConstants.REFRESH_TOKEN, oAuth2TokenInfo.getRefreshToken());
                 returnProperties.put(IdPClientConstants.VALIDITY_PERIOD,
                         Long.toString(oAuth2TokenInfo.getExpiresIn()));
-                returnProperties.put(ExternalIdPClientConstants.REDIRECT_URL, this.baseUrl + appContext);
-
+                if (this.baseUrl.endsWith("/")) {
+                    returnProperties.put(ExternalIdPClientConstants.REDIRECT_URL, this.baseUrl + appContext);
+                } else {
+                    returnProperties.put(ExternalIdPClientConstants.REDIRECT_URL, this.baseUrl + "/" + appContext);
+                }
                 Response introspectTokenResponse = oAuth2ServiceStubs.getIntrospectionServiceStub()
                         .introspectAccessToken(oAuth2TokenInfo.getAccessToken());
                 String authUser = null;
@@ -385,7 +388,11 @@ public class ExternalIdPClient implements IdPClient {
                     OAuth2IntrospectionResponse introspectResponse = (OAuth2IntrospectionResponse) new GsonDecoder()
                             .decode(introspectTokenResponse, OAuth2IntrospectionResponse.class);
                     String username = introspectResponse.getUsername();
-                    authUser = username.substring(0, username.indexOf("@carbon.super"));
+                    if (username.contains("@carbon.super")) {
+                        authUser = username.substring(0, username.indexOf("@carbon.super"));
+                    } else {
+                        authUser = username;
+                    }
                     returnProperties.put(IdPClientConstants.USERNAME, authUser);
                 } else {
                     if (LOG.isDebugEnabled()) {

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
@@ -233,7 +233,13 @@ public class ExternalIdPClient implements IdPClient {
                             scimGroups.forEach(scimGroup -> {
                                         JsonElement displayName = ((JsonObject) scimGroup)
                                                 .get(ExternalIdPClientConstants.SCIM2_DISPLAY);
-                                        userGroupsDisplayNameList.add(displayName.getAsString());
+                                        if (displayName.getAsString().contains("/")) {
+                                            userGroupsDisplayNameList.add(displayName.getAsString());
+                                        } else {
+                                            userGroupsDisplayNameList.
+                                                    add(ExternalIdPClientConstants.PRIMARY_USER_STORE_PREFIX +
+                                                            displayName.getAsString());
+                                        }
                                     }
                             );
                             userRoles = allRolesInUserStore.stream()
@@ -356,7 +362,7 @@ public class ExternalIdPClient implements IdPClient {
         }
         OAuthApplicationInfo oAuthApplicationInfo = this.oAuthAppInfoMap.get(oAuthAppContext);
         Response response = oAuth2ServiceStubs.getTokenServiceStub().generateAuthCodeGrantAccessToken(code,
-                this.baseUrl + ExternalIdPClientConstants.CALLBACK_URL + oAuthAppContext, null,
+                this.baseUrl + ExternalIdPClientConstants.CALLBACK_URL + appContext, null,
                 oAuthApplicationInfo.getClientId(), oAuthApplicationInfo.getClientSecret());
         if (response == null) {
             String error = "Error occurred while generating an access token from code '" + code + "'. " +

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
@@ -83,7 +83,7 @@ public class ExternalIdPClientConstants {
     public static final String CALLBACK_URL_NAME = "Callback_Url";
     public static final String REQUEST_URL = "REQUEST_URL";
 
-    public static final String CALLBACK_URL = "/login/callback";
+    public static final String CALLBACK_URL = "/login/callback/";
     public static final String REGEX_BASE_START = "regexp=(";
     public static final String FORWARD_SLASH = "/";
     public static final String REGEX_BASE_END = ".*)";

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
@@ -52,6 +52,7 @@ public class ExternalIdPClientConstants {
     public static final String DCR_APP_OWNER = "dcrAppOwner";
     public static final String CONNECTION_TIMEOUT = "connectionTimeout";
     public static final String READ_TIMEOUT = "readTimeout";
+    public static final String EXTERNAL_SSO_LOGOUT_URL = "externalLogoutUrl";
 
     public static final String DEFAULT_BASE_URL = "https://localhost:9643";
     public static final String DEFAULT_KM_TOKEN_URL = "https://localhost:9443/oauth2";
@@ -72,6 +73,7 @@ public class ExternalIdPClientConstants {
     public static final String DEFAULT_DATABASE_NAME = "WSO2_OAUTH_APP_DB";
     public static final String DEFAULT_CONNECTION_TIMEOUT = "10000";
     public static final String DEFAULT_READ_TIMEOUT = "60000";
+    public static final String DEFAULT_EXTERNAL_SSO_LOGOUT_URL = "https://localhost:9443/samlsso";
 
     public static final String SP_APP_NAME = "sp";
     public static final String PORTAL_APP_NAME = "sp_portal";
@@ -97,6 +99,7 @@ public class ExternalIdPClientConstants {
     public static final String TOKEN_POSTFIX = "/token";
     public static final String INTROSPECT_POSTFIX = "/introspect";
     public static final String AUTHORIZE_POSTFIX = "/authorize";
+    public static final String PRIMARY_USER_STORE_PREFIX = "PRIMARY/";
 
     public static final String SCIM2_USERNAME = "userName";
     public static final String SCIM2_GROUPS = "groups";

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
@@ -99,7 +99,6 @@ public class ExternalIdPClientConstants {
     public static final String TOKEN_POSTFIX = "/token";
     public static final String INTROSPECT_POSTFIX = "/introspect";
     public static final String AUTHORIZE_POSTFIX = "/authorize";
-    public static final String PRIMARY_USER_STORE_PREFIX = "PRIMARY/";
 
     public static final String SCIM2_USERNAME = "userName";
     public static final String SCIM2_GROUPS = "groups";


### PR DESCRIPTION
## Purpose
This PR adds support for SSO via the External IDP client

## Approach
To enable SSO support add the following configurations in the relevant deployment.yaml.

```yaml
# Authentication configuration
auth.configs:
  type: external
  ssoEnabled: true
  properties:
    kmDcrUrl: https://localhost:9443/identity/connect/register
    kmTokenUrl: https://localhost:9443/oauth2
    kmUsername: admin
    kmPassword: admin
    idpBaseUrl: https://localhost:9443/scim2
    idpUsername: admin
    idpPassword: admin
    portalAppContext: portal
    statusDashboardAppContext: monitoring
    businessRulesAppContext : business-rules
    databaseName: WSO2_OAUTH_APP_DB
    cacheTimeout: 900
    baseUrl: https://localhost:9643
    grantType: authorization_code
    externalLogoutUrl: https://localhost:9443/samlsso
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes