### PR TITLE
Fix dynamic registration even when client id and client secret is given

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
@@ -124,6 +124,11 @@ public class ExternalIdPClient implements IdPClient {
                     this.oAuthAppDAO.updateOAuthApp(persistedOAuthApp);
                 }
                 this.oAuthAppInfoMap.replace(oAuthApplicationInfoEntry.getKey(), persistedOAuthApp);
+            } else if (clientId != null && clientSecret != null) {
+                OAuthApplicationInfo oAuthApplicationInfo =
+                        new OAuthApplicationInfo(oAuthApplicationInfoEntry.getKey(), clientId, clientSecret);
+                this.oAuthAppDAO.addOAuthApp(oAuthApplicationInfo);
+                this.oAuthAppInfoMap.replace(oAuthApplicationInfoEntry.getKey(), oAuthApplicationInfo);
             } else {
                 registerApplication(oAuthApplicationInfoEntry.getKey(),
                         oAuthApplicationInfoEntry.getValue().getClientName(), kmUserName);


### PR DESCRIPTION
## Purpose
$subject. there is no need for dynamic registration if the client Id and secret are configured.

## Documentation
N/A as it is a bug fix

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes