### PR TITLE
Fix adding redundant records in permission table

### DIFF
--- a/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/internal/dao/PermissionsDAO.java
+++ b/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/internal/dao/PermissionsDAO.java
@@ -300,6 +300,12 @@ public class PermissionsDAO {
      * @param role
      */
     public void grantPermission(Permission permission, Role role) {
+        List<Role> roles = new ArrayList<>();
+        roles.add(role);
+        if (hasPermission(roles, permission)) {
+            return;
+        }
+
         Connection conn = null;
         PreparedStatement ps = null;
         String uuid = PermissionUtil.createPermissionID(permission);


### PR DESCRIPTION
## Purpose
In the permission provider, granting permissions on particular permission for a role does not check if the permission has already been granted. This results in data redundancy issue in the `ROLE_PERMISSIONS` table. 

Resolves https://github.com/wso2/carbon-analytics-common/issues/537

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes