### PR TITLE
Fix SSO callback URL

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
@@ -484,12 +484,11 @@ public class ExternalIdPClient implements IdPClient {
         String callBackUrl;
         if (clientName.equals(ExternalIdPClientConstants.DEFAULT_SP_APP_CONTEXT)) {
             callBackUrl = ExternalIdPClientConstants.REGEX_BASE_START + this.baseUrl +
-                    ExternalIdPClientConstants.CALLBACK_URL + ExternalIdPClientConstants.FORWARD_SLASH +
-                    ExternalIdPClientConstants.REGEX_BASE_END;
+                    ExternalIdPClientConstants.CALLBACK_URL + ExternalIdPClientConstants.REGEX_BASE_END;
         } else {
             callBackUrl = ExternalIdPClientConstants.REGEX_BASE_START + this.baseUrl +
-                    ExternalIdPClientConstants.CALLBACK_URL + ExternalIdPClientConstants.FORWARD_SLASH
-                    + appContext + ExternalIdPClientConstants.REGEX_BASE_END;
+                    ExternalIdPClientConstants.CALLBACK_URL + appContext +
+                    ExternalIdPClientConstants.REGEX_BASE_END;
         }
 
         if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
## Purpose
On DCR call, the SSO callback URL is getting created with additional forward slash `/`. This invalidates the SSO authentication process. 

## Approach
This PR removes the additional forward slash on DCR call.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes