### PR TITLE
Add SSO support for IS 5.2.0

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
@@ -70,23 +70,25 @@ public class ExternalIdPClient implements IdPClient {
     private String signingAlgo;
     private String adminRoleDisplayName;
     private OAuthAppDAO oAuthAppDAO;
-
+    private String defaultUserStore;
     private Cache<String, ExternalSession> tokenCache;
 
     //Here the user given context are mapped to the OAuthApp Info.
     private Map<String, OAuthApplicationInfo> oAuthAppInfoMap;
 
-    public ExternalIdPClient(String baseUrl, String authorizeEndpoint, String grantType, String singingAlgo,
+    public ExternalIdPClient(String baseUrl, String authorizeEndpoint, String grantType, String signinAlgo,
                              String adminRoleDisplayName, Map<String, OAuthApplicationInfo> oAuthAppInfoMap,
                              int cacheTimeout, OAuthAppDAO oAuthAppDAO, DCRMServiceStub dcrmServiceStub,
-                             OAuth2ServiceStubs oAuth2ServiceStubs, SCIM2ServiceStub scimServiceStub)
-            throws IdPClientException {
+                             OAuth2ServiceStubs oAuth2ServiceStubs, SCIM2ServiceStub scimServiceStub,
+                             String defaultUserStore) {
         this.baseUrl = baseUrl;
         this.authorizeEndpoint = authorizeEndpoint;
         this.grantType = grantType;
-        this.signingAlgo = singingAlgo;
+        this.signingAlgo = signinAlgo;
         this.oAuthAppInfoMap = oAuthAppInfoMap;
-        this.adminRoleDisplayName = adminRoleDisplayName;
+        // If the admin role doesn't contain the user store, prepend the default user store.
+        this.adminRoleDisplayName = adminRoleDisplayName.contains("/") ?
+                adminRoleDisplayName  : defaultUserStore + "/" +  adminRoleDisplayName;
         this.oAuthAppDAO = oAuthAppDAO;
         this.dcrmServiceStub = dcrmServiceStub;
         this.oAuth2ServiceStubs = oAuth2ServiceStubs;
@@ -94,6 +96,7 @@ public class ExternalIdPClient implements IdPClient {
         this.tokenCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(cacheTimeout, TimeUnit.SECONDS)
                 .build();
+        this.defaultUserStore = defaultUserStore;
     }
 
     private static String removeCRLFCharacters(String str) {
@@ -108,11 +111,16 @@ public class ExternalIdPClient implements IdPClient {
         if (!this.oAuthAppDAO.tableExists()) {
             this.oAuthAppDAO.createTable();
         }
-        for (Map.Entry<String, OAuthApplicationInfo> oAuthApplicationInfoEntry : this.oAuthAppInfoMap.entrySet()) {
-            String clientId = oAuthApplicationInfoEntry.getValue().getClientId();
-            String clientSecret = oAuthApplicationInfoEntry.getValue().getClientSecret();
-            OAuthApplicationInfo persistedOAuthApp =
-                    this.oAuthAppDAO.getOAuthApp(oAuthApplicationInfoEntry.getValue().getClientName());
+
+        for (Map.Entry<String, OAuthApplicationInfo> entry : this.oAuthAppInfoMap.entrySet()) {
+            String appContext = entry.getKey();
+            OAuthApplicationInfo oAuthApp = entry.getValue();
+
+            String clientId = oAuthApp.getClientId();
+            String clientSecret = oAuthApp.getClientSecret();
+            String clientName = oAuthApp.getClientName();
+
+            OAuthApplicationInfo persistedOAuthApp = this.oAuthAppDAO.getOAuthApp(clientName);
             if (persistedOAuthApp != null) {
                 if (clientId != null || clientSecret != null) {
                     if (clientId != null) {
@@ -123,15 +131,13 @@ public class ExternalIdPClient implements IdPClient {
                     }
                     this.oAuthAppDAO.updateOAuthApp(persistedOAuthApp);
                 }
-                this.oAuthAppInfoMap.replace(oAuthApplicationInfoEntry.getKey(), persistedOAuthApp);
+                this.oAuthAppInfoMap.replace(appContext, persistedOAuthApp);
             } else if (clientId != null && clientSecret != null) {
-                OAuthApplicationInfo oAuthApplicationInfo =
-                        new OAuthApplicationInfo(oAuthApplicationInfoEntry.getKey(), clientId, clientSecret);
-                this.oAuthAppDAO.addOAuthApp(oAuthApplicationInfo);
-                this.oAuthAppInfoMap.replace(oAuthApplicationInfoEntry.getKey(), oAuthApplicationInfo);
+                OAuthApplicationInfo newOAuthApp = new OAuthApplicationInfo(clientName, clientId, clientSecret);
+                this.oAuthAppDAO.addOAuthApp(newOAuthApp);
+                this.oAuthAppInfoMap.replace(appContext, newOAuthApp);
             } else {
-                registerApplication(oAuthApplicationInfoEntry.getKey(),
-                        oAuthApplicationInfoEntry.getValue().getClientName(), kmUserName);
+                registerApplication(appContext, clientName, kmUserName);
             }
         }
     }
@@ -149,9 +155,9 @@ public class ExternalIdPClient implements IdPClient {
                 SCIMGroupList scimGroups = (SCIMGroupList) new GsonDecoder().decode(response, SCIMGroupList.class);
                 List<SCIMGroupList.SCIMGroupResources> resources = scimGroups.getResources();
                 if (resources != null) {
-                    return resources.stream().map(
-                            (resource) -> new Role(resource.getId(), resource.getDisplayName())
-                    ).collect(Collectors.toList());
+                    return resources.stream()
+                            .map((resource) -> new Role(resource.getId(), resource.getDisplayName()))
+                            .collect(Collectors.toList());
                 }
                 return new ArrayList<>();
             } catch (IOException e) {
@@ -170,8 +176,7 @@ public class ExternalIdPClient implements IdPClient {
 
     @Override
     public Role getAdminRole() throws IdPClientException {
-        Response response = scimServiceStub
-                .getFilteredGroups(ExternalIdPClientConstants.FILTER_PREFIX_GROUP + this.adminRoleDisplayName);
+        Response response = scimServiceStub.getAllGroups();
         if (response == null) {
             String errorMessage = "Error occurred while retrieving admin group '" + this.adminRoleDisplayName +
                     "'. Error : Response is null.";
@@ -183,7 +188,11 @@ public class ExternalIdPClient implements IdPClient {
                 SCIMGroupList scimGroups = (SCIMGroupList) new GsonDecoder().decode(response, SCIMGroupList.class);
                 List<SCIMGroupList.SCIMGroupResources> resources = scimGroups.getResources();
                 if (resources != null) {
-                    return new Role(resources.get(0).getId(), resources.get(0).getDisplayName());
+                    for (SCIMGroupList.SCIMGroupResources resource : resources) {
+                        if (resource.getDisplayName().equalsIgnoreCase(this.adminRoleDisplayName)) {
+                            return new Role(resource.getId(), resource.getDisplayName());
+                        }
+                    }
                 }
                 String errorMessage = "Error occurred while retrieving admin group '" + this.adminRoleDisplayName +
                         "'. Admin role not found in the user store.";
@@ -207,55 +216,63 @@ public class ExternalIdPClient implements IdPClient {
     public User getUser(String name) throws IdPClientException {
         Response response = scimServiceStub.searchUser(ExternalIdPClientConstants.FILTER_PREFIX_USER + name);
         if (response == null) {
-            String errorMessage =
-                    "Error occurred while retrieving user, '" + name + "'. Error : Response is null.";
+            String errorMessage = "Error occurred while retrieving user, '" + name + "'. Error : Response is null.";
             LOG.error(errorMessage);
             throw new IdPClientException(errorMessage);
         }
+
+        JsonParser parser = new JsonParser();
         if (response.status() == 200) {
-            String responseBody = response.body().toString();
-            JsonParser parser = new JsonParser();
-            JsonObject parsedResponseBody = (JsonObject) parser.parse(responseBody);
-            JsonArray users = (JsonArray) parsedResponseBody.get(ExternalIdPClientConstants.RESOURCES);
-            if (users != null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Retrieving all roles for getting role id of the roles of the user '" + name + "'.");
-                }
-                List<Role> allRolesInUserStore = getAllRoles();
+            JsonObject userObject = parser.parse(response.body().toString()).getAsJsonObject();
+            JsonArray users = userObject.get(ExternalIdPClientConstants.RESOURCES).getAsJsonArray();
 
-                Map<String, String> userProperties = new HashMap<>();
-                List<Role> userRoles = new ArrayList<>();
-
-                JsonObject scimUser = (JsonObject) users.get(0);
-                for (Map.Entry<String, JsonElement> entry : scimUser.entrySet()) {
-                    switch (entry.getKey()) {
-                        case ExternalIdPClientConstants.SCIM2_USERNAME:
-                            break;
-                        case ExternalIdPClientConstants.SCIM2_GROUPS:
-                            JsonArray scimGroups = scimUser.get(ExternalIdPClientConstants.SCIM2_GROUPS)
-                                    .getAsJsonArray();
-                            List<String> userGroupsDisplayNameList = new ArrayList<>();
-                            scimGroups.forEach(scimGroup -> {
-                                        JsonElement displayName = ((JsonObject) scimGroup)
-                                                .get(ExternalIdPClientConstants.SCIM2_DISPLAY);
-                                        userGroupsDisplayNameList.add(displayName.getAsString());
-                                    }
-                            );
-                            userRoles = allRolesInUserStore.stream()
-                                    .filter(role -> userGroupsDisplayNameList.contains(role.getDisplayName()))
-                                    .collect(Collectors.toList());
-                            break;
-                        default:
-                            userProperties.put(entry.getKey(), entry.getValue().toString());
-                    }
-                }
-                return new User(name, userProperties, userRoles);
-            } else {
+            if (users == null) {
                 return null;
             }
+
+            JsonObject user = users.get(0).getAsJsonObject();
+            // Check if the user groups are there in the user object. If not do a separate call and get the user with
+            // roles.
+            JsonElement groupsElement = user.get(ExternalIdPClientConstants.SCIM2_GROUPS);
+            JsonArray groups;
+            if (groupsElement != null) {
+                groups = groupsElement.getAsJsonArray();
+            } else {
+                String id = user.get(ExternalIdPClientConstants.SCIM2_ID).getAsString();
+                Response userResponse = scimServiceStub.getUserByID(id);
+                user = parser.parse(userResponse.body().toString()).getAsJsonObject();
+                groups = user.get(ExternalIdPClientConstants.SCIM2_GROUPS).getAsJsonArray();
+            }
+
+            // Get user roles
+            List<Role> allRolesInUserStore = getAllRoles();
+            List<String> groupNameList = new ArrayList<>();
+            groups.forEach(group -> {
+                // In SCIM1 (IS 5.2.0) groupName doesn't contain the user store, but 5.7.0 it is. Hence prepending the
+                // user store if it is not available as a workaround. Need a proper fix for this though.
+                String groupName = group.getAsJsonObject().get(ExternalIdPClientConstants.SCIM2_DISPLAY).getAsString();
+                if (!groupName.contains("/")) {
+                    groupName = this.defaultUserStore + "/" + groupName;
+                }
+                groupNameList.add(groupName);
+            });
+
+            List<Role> roles = allRolesInUserStore.stream()
+                    .filter(role -> groupNameList.contains(role.getDisplayName()))
+                    .collect(Collectors.toList());
+
+            // Add user properties
+            Map<String, String> properties = new HashMap<>();
+            for (Map.Entry<String, JsonElement> entry : user.entrySet()) {
+                if (!entry.getKey().equals(ExternalIdPClientConstants.SCIM2_USERNAME) ||
+                    !entry.getKey().equals(ExternalIdPClientConstants.SCIM2_GROUPS)) {
+                    properties.put(entry.getKey(), entry.getValue().toString());
+                }
+            }
+            return new User(name, properties, roles);
         } else {
-            String errorMessage = "Error occurred while retrieving user, '" + name + "'. HTTP error code: "
-                    + response.status() + " Error Response: " + getErrorMessage(response);
+            String errorMessage = "Error occurred while retrieving user, '" + name + "'. " +
+                    "HTTP error code: " + response.status() + " Error Response: " + getErrorMessage(response);
             LOG.error(errorMessage);
             throw new IdPClientException(errorMessage);
         }
@@ -263,15 +280,14 @@ public class ExternalIdPClient implements IdPClient {
 
     @Override
     public List<Role> getUserRoles(String name) throws IdPClientException {
-        List<Role> userGroups = new ArrayList<>();
         if (LOG.isDebugEnabled()) {
             LOG.debug("Retrieving user roles by retrieving user '" + name + "'.");
         }
         User user = getUser(name);
         if (user != null) {
-            userGroups = user.getRoles();
+            return user.getRoles();
         }
-        return userGroups;
+        return new ArrayList<>();
     }
 
     @Override
@@ -440,10 +456,11 @@ public class ExternalIdPClient implements IdPClient {
 
     @Override
     public String authenticate(String token) throws AuthenticationException, IdPClientException {
-        ExternalSession ifPresent = tokenCache.getIfPresent(token);
-        if (ifPresent != null) {
-            return ifPresent.getUserName();
+        ExternalSession session = tokenCache.getIfPresent(token);
+        if (session != null) {
+            return session.getUserName();
         }
+
         Response response = oAuth2ServiceStubs.getIntrospectionServiceStub()
                 .introspectAccessToken(token);
 

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientConstants.java
@@ -84,6 +84,9 @@ public class ExternalIdPClientConstants {
     public static final String REDIRECT_URL = "Redirect_Url";
     public static final String CALLBACK_URL_NAME = "Callback_Url";
     public static final String REQUEST_URL = "REQUEST_URL";
+    public static final String USER_STORE = "defaultUserStore";
+    public static final String DEFAULT_USER_STORE = "PRIMARY";
+    public static final String INTROSPECTION_URL = "introspectionUrl";
 
     public static final String CALLBACK_URL = "/login/callback/";
     public static final String REGEX_BASE_START = "regexp=(";
@@ -103,6 +106,7 @@ public class ExternalIdPClientConstants {
     public static final String SCIM2_USERNAME = "userName";
     public static final String SCIM2_GROUPS = "groups";
     public static final String SCIM2_DISPLAY = "display";
+    public static final String SCIM2_ID = "id";
 
     public static final String OAUTHAPP_TABLE = "OAUTHAPP";
     public static final String OAUTH_APP_TABLE_CHECK = "OAUTH_APP_TABLE_CHECK";

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientFactory.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClientFactory.java
@@ -152,6 +152,8 @@ public class ExternalIdPClientFactory implements IdPClientFactory {
         String kmTokenUrl = properties.getOrDefault(ExternalIdPClientConstants.KM_TOKEN_URL,
                 ExternalIdPClientConstants.DEFAULT_KM_TOKEN_URL);
         String dcrAppOwner = properties.getOrDefault(ExternalIdPClientConstants.DCR_APP_OWNER, kmUsername);
+        String introspectUrl = properties.getOrDefault(ExternalIdPClientConstants.INTROSPECTION_URL,
+                kmTokenUrl + ExternalIdPClientConstants.INTROSPECT_POSTFIX);
 
         String idPBaseUrl = properties.getOrDefault(ExternalIdPClientConstants.IDP_BASE_URL,
                 ExternalIdPClientConstants.DEFAULT_IDP_BASE_URL);
@@ -174,6 +176,9 @@ public class ExternalIdPClientFactory implements IdPClientFactory {
                 ExternalIdPClientConstants.DEFAULT_STATUS_DB_APP_CONTEXT);
         String businessAppContext = properties.getOrDefault(ExternalIdPClientConstants.BR_DB_APP_CONTEXT,
                 ExternalIdPClientConstants.DEFAULT_BR_DB_APP_CONTEXT);
+
+        String defaultUserStore = properties.getOrDefault(ExternalIdPClientConstants.USER_STORE,
+                ExternalIdPClientConstants.DEFAULT_USER_STORE);
 
         OAuthApplicationInfo spOAuthApp = new OAuthApplicationInfo(
                 ExternalIdPClientConstants.SP_APP_NAME,
@@ -220,8 +225,7 @@ public class ExternalIdPClientFactory implements IdPClientFactory {
                 .build(kmUsername, kmPassword, connectionTimeout, readTimeout, DCRMServiceStub.class, dcrEndpoint);
         OAuth2ServiceStubs keyManagerServiceStubs = new OAuth2ServiceStubs(
                 this.analyticsHttpClientBuilderService, kmTokenUrl + ExternalIdPClientConstants.TOKEN_POSTFIX,
-                kmTokenUrl + ExternalIdPClientConstants.REVOKE_POSTFIX,
-                kmTokenUrl + ExternalIdPClientConstants.INTROSPECT_POSTFIX,
+                kmTokenUrl + ExternalIdPClientConstants.REVOKE_POSTFIX, introspectUrl,
                 kmUsername, kmPassword, connectionTimeout, readTimeout);
         SCIM2ServiceStub scimServiceStub = this.analyticsHttpClientBuilderService
                 .build(idPUserName, idPPassword, connectionTimeout, readTimeout, SCIM2ServiceStub.class, idPBaseUrl);
@@ -231,7 +235,7 @@ public class ExternalIdPClientFactory implements IdPClientFactory {
         ExternalIdPClient externalIdPClient = new ExternalIdPClient(baseUrl,
                 kmTokenUrl + ExternalIdPClientConstants.AUTHORIZE_POSTFIX, grantType, signingAlgo,
                 adminRoleDisplayName, oAuthAppInfoMap, cacheTimeout, oAuthAppDAO, dcrmServiceStub,
-                keyManagerServiceStubs, scimServiceStub);
+                keyManagerServiceStubs, scimServiceStub, defaultUserStore);
         externalIdPClient.init(dcrAppOwner);
         return externalIdPClient;
     }

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/impl/SCIM2ServiceStub.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/impl/SCIM2ServiceStub.java
@@ -35,4 +35,6 @@ public interface SCIM2ServiceStub {
     @RequestLine("GET /Groups?filter={query}")
     Response getFilteredGroups(@Param("query") String query);
 
+    @RequestLine("GET /Users/{id}")
+    Response getUserByID(@Param("id") String id);
 }


### PR DESCRIPTION
## Purpose
WSO2 IS 5.2.0 supports SCIM1 while the newer versions support SCIM2 as well. Previous SSO implementation used SCIM2 for the authorization process, hence it did not work with IS 5.2.0 and less. This PR adds the SSO support with IS 5.2.0.

## Approach
Sample `deployment.yaml` for SSO with IS 5.2.0:

```yaml
auth.configs:
  type: external
  ssoEnabled: true
  userManager:
    adminRole: admin
  properties:
    introspectionUrl: https://localhost:9443/introspect
    kmDcrUrl: https://localhost:9443/identity/connect/register
    kmTokenUrl: https://localhost:9443/oauth2
    kmUsername: admin
    kmPassword: admin
    idpBaseUrl: https://localhost:9443/wso2/scim
    idpUsername: admin
    idpPassword: admin
    portalAppContext: portal
    statusDashboardAppContext: monitoring
    businessRulesAppContext : business-rules
    databaseName: WSO2_OAUTH_APP_DB
    cacheTimeout: 900
    baseUrl: https://localhost:9643
    grantType: authorization_code
    externalLogoutUrl: https://localhost:9443/samlsso
    spClientId: c52opwfRAoiIu4mKf1jjWKLHpiQa
    spClientSecret: ukAc3efonRMh5fs_8CvGTf6FsEUa
    portalClientId: LEnHOuOl04ko76UoJRzqfzlijQMa
    portalClientSecret: voCsvftJfKhFXRWBRUbcnNEtmdQa
    statusDashboardClientId: tLF4iLr0uGN7fGxGPz_x5dPBbEMa
    statusDashboardClientSecret: 3flgvBtneZbrKfFQrgWuO6kTSR4a
    businessRulesClientId: LJmXewPp4GGNbZXXOqAemrgERWwa
    businessRulesClientSecret: XvKwBLC22trghvwfRcGgLYZpmVAa
    defaultUserStore: PRIMARY
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes