### PR TITLE
When Inserting data to MsSQL database by using DB output event adapter, it throws "RDBMSEventAdapter Cannot Execute Create Table Query. There is already an object named '<DB_NAME>' in the database. Hence Event is dropped."

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.rdbms/src/main/java/org/wso2/carbon/event/output/adapter/rdbms/RDBMSEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.rdbms/src/main/java/org/wso2/carbon/event/output/adapter/rdbms/RDBMSEventAdapter.java
@@ -701,6 +701,9 @@ public class RDBMSEventAdapter implements OutputEventAdapter {
                 DatabaseMetaData databaseMetaData = con.getMetaData();
                 dbName = databaseMetaData.getDatabaseProductName();
                 dbName = dbName.toLowerCase();
+                if(dbName.equals("microsoft sql server")){
+                    dbName = "mssql";
+                }
             } else {
                 throw new OutputEventAdapterException("There is no data-source called " + eventAdapterConfiguration
                         .getStaticProperties().get(RDBMSEventAdapterConstants.ADAPTER_GENERIC_RDBMS_DATASOURCE_NAME));


### PR DESCRIPTION
## Purpose
If used DB output event adapter in order to persist the data which has published to a stream in TM side. When invoking the DB output event adapter and has pointed the DB type as Ms SQL, then it will show the below exception.
```
2019-06-14 14:18:09,192] ERROR - RDBMSEventAdapter Cannot Execute Create Table Query. There is already an object named 'AM_BOT_DATA' in the database. Hence Event is dropped.
org.wso2.carbon.event.output.adapter.core.exception.OutputEventAdapterException: Cannot Execute Create Table Query. There is already an object named 'AM_DATA' in the database.
	at org.wso2.carbon.event.output.adapter.rdbms.RDBMSEventAdapter.createTableIfNotExist(RDBMSEventAdapter.java:627)
	at org.wso2.carbon.event.output.adapter.rdbms.RDBMSEventAdapter.executeProcessActions
:
```
Please refer this issue[1] for more information.

## Goals
- To fix the "RDBMSEventAdapter Cannot Execute Create Table Query. There is already an object named '<DB_NAME>' in the database. Hence Event is dropped." exception when using the MsSQL as RDMS database. 

## Approach
Reason for the issue is the passing value for the DB name from the JDBC driver which is not compatible for the configured value in the files.  Since changed the required value from the DB in order to fix this issue. Tested the solution against APIM 2.6.0 (2.x).

[1]. https://github.com/wso2/product-apim/issues/5007

