### PR TITLE
Add JMS_EXPIRATION setter for expiration defined in message

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.jms/src/main/java/org/wso2/carbon/event/output/adapter/jms/internal/util/JMSMessageSender.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.jms/src/main/java/org/wso2/carbon/event/output/adapter/jms/internal/util/JMSMessageSender.java
@@ -115,6 +115,12 @@ public class JMSMessageSender {
                 } catch (JMSException e) {
                     handleConnectionException("Error setting JMS Producer TTL to : " + timeToLive, e);
                 }
+            } else if (jmsMessage.getJMSExpiration() > 0) {
+                try {
+                    producer.setTimeToLive(jmsMessage.getJMSExpiration());
+                } catch (JMSException e) {
+                    handleConnectionException("Error setting JMS Producer TTL to : " + jmsMessage.getJMSExpiration(), e);
+                }
             }
 
             // perform actual message sending


### PR DESCRIPTION
## Purpose
Adding JMS_EXPIRATION setter for expiration defined in message
- Made change to JMSMessageSender class to handle JMS_Expiration when defined in Message.

- Event producer can now set JMS_Expiration property as a
header which will be set by the producer using setTimeToLive

Resolves: https://github.com/wso2/product-ei/issues/4387