### PR TITLE
Add JMS header parameters via property

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.jms/src/main/java/org/wso2/carbon/event/output/adapter/jms/internal/util/JMSMessageSender.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.jms/src/main/java/org/wso2/carbon/event/output/adapter/jms/internal/util/JMSMessageSender.java
@@ -72,9 +72,6 @@ public class JMSMessageSender {
 
         Boolean jtaCommit = getBooleanProperty(messageProperties, BaseConstants.JTA_COMMIT_AFTER_SEND);
         Boolean rollbackOnly = getBooleanProperty(messageProperties, BaseConstants.SET_ROLLBACK_ONLY);
-        Boolean persistent = getBooleanProperty(messageProperties, JMSConstants.JMS_DELIVERY_MODE);
-        Integer priority = getIntegerProperty(messageProperties, JMSConstants.JMS_PRIORITY);
-        Integer timeToLive = getIntegerProperty(messageProperties, JMSConstants.JMS_TIME_TO_LIVE);
 
         MessageProducer producer = null;
         Destination destination = null;
@@ -95,33 +92,9 @@ public class JMSMessageSender {
                 jtaCommit = Boolean.FALSE;
             }
 
-            if (persistent != null) {
-                try {
-                    producer.setDeliveryMode(DeliveryMode.PERSISTENT);
-                } catch (JMSException e) {
-                    handleConnectionException("Error setting JMS Producer for PERSISTENT delivery", e);
-                }
-            }
-            if (priority != null) {
-                try {
-                    producer.setPriority(priority);
-                } catch (JMSException e) {
-                    handleConnectionException("Error setting JMS Producer priority to : " + priority, e);
-                }
-            }
-            if (timeToLive != null) {
-                try {
-                    producer.setTimeToLive(timeToLive);
-                } catch (JMSException e) {
-                    handleConnectionException("Error setting JMS Producer TTL to : " + timeToLive, e);
-                }
-            } else if (jmsMessage.getJMSExpiration() > 0) {
-                try {
-                    producer.setTimeToLive(jmsMessage.getJMSExpiration());
-                } catch (JMSException e) {
-                    handleConnectionException("Error setting JMS Producer TTL to : " + jmsMessage.getJMSExpiration(), e);
-                }
-            }
+            producer.setDeliveryMode(jmsMessage.getJMSDeliveryMode());
+            producer.setPriority(jmsMessage.getJMSPriority());
+            producer.setTimeToLive(jmsMessage.getJMSExpiration());
 
             // perform actual message sending
 //        try {


### PR DESCRIPTION
Adding JMS header parameters via property

- Made change to JMSMessageSender class to handle JMS_Expiration and other header parameters when defined in Message.
- Event producer can now set JMS_Expiration property as a
header which will be set by the producer using setTimeToLive

Resolves: wso2/product-ei#4387