### PR TITLE
Change namespace of idp client conf to authentication

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/IdPClientConstants.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/IdPClientConstants.java
@@ -27,6 +27,7 @@ public class IdPClientConstants {
     public static final String REFRESH_GRANT_TYPE = "refresh_token";
 
     public static final String SP_AUTH_NAMESPACE = "auth.configs";
+    public static final String STREAMLINED_AUTH_NAMESPACE = "authentication";
 
     public static final String LOGIN_STATUS = "Status";
     public static final String REDIRECTION_URL = "Redirect_Url";

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/IdPServiceUtils.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/IdPServiceUtils.java
@@ -28,6 +28,9 @@ import org.wso2.carbon.config.provider.ConfigProvider;
 
 import java.util.Map;
 
+import static org.wso2.carbon.analytics.idp.client.core.utils.IdPClientConstants.SP_AUTH_NAMESPACE;
+import static org.wso2.carbon.analytics.idp.client.core.utils.IdPClientConstants.STREAMLINED_AUTH_NAMESPACE;
+
 /**
  * IdP Client Utils.
  */
@@ -40,12 +43,17 @@ public class IdPServiceUtils {
         IdPClient idPClient;
         try {
             IdPClientConfiguration idPClientConfiguration;
-            if (configProvider.getConfigurationObject(IdPClientConstants.SP_AUTH_NAMESPACE) == null) {
-                idPClientConfiguration = new IdPClientConfiguration();
-                LOG.info("Enabling default IdPClient Local User Store as configuration is not overridden.");
+
+            if (configProvider.getConfigurationObject(STREAMLINED_AUTH_NAMESPACE) != null) {
+                LOG.debug("Extract IdP Client configs from under 'authentication' namespace.");
+                idPClientConfiguration = configProvider.getConfigurationObject(
+                        STREAMLINED_AUTH_NAMESPACE, IdPClientConfiguration.class);
+            } else if (configProvider.getConfigurationObject(SP_AUTH_NAMESPACE) != null) {
+                LOG.debug("Extract IdP Client configs from under 'auth.configs' namespace.");
+                idPClientConfiguration = configProvider.getConfigurationObject(IdPClientConfiguration.class);
             } else {
-                idPClientConfiguration = configProvider.
-                        getConfigurationObject(IdPClientConfiguration.class);
+                LOG.info("Enabling default IdPClient Local User Store as configuration is not overridden.");
+                idPClientConfiguration = new IdPClientConfiguration();
             }
             idPClientFactory = idPClientFactoryMap.get(idPClientConfiguration.getType());
             if (idPClientFactory == null) {
@@ -54,8 +62,7 @@ public class IdPServiceUtils {
             idPClient = idPClientFactory.getIdPClient(idPClientConfiguration);
             LOG.info("IdP client of type '" + idPClientConfiguration.getType() + "' is started.");
         } catch (ConfigurationException e) {
-            throw new IdPClientException("Error in reading '" + IdPClientConstants.SP_AUTH_NAMESPACE + "' from file.",
-                    e);
+            throw new IdPClientException("Error in reading '" + SP_AUTH_NAMESPACE + "' from file.", e);
         }
         return idPClient;
     }


### PR DESCRIPTION
## Purpose
$subject
```
# Authentication configuration
authentication:
  type: 'local'        # Type of the IdP client used
  userManager:
    adminRole: admin   # Admin role which is granted all permissions
    userStore:         # User store
      users:
        -
          user:
            username: admin
            password: YWRtaW4=
            roles: 1
      roles:
        -
          role:
            id: 1
            displayName: admin
```

## Goals
Streamline configurations

## Documentation
N/A as it is backward compatible

## Automation tests
 - Unit tests - Passes All
 - Integration tests - Passess All

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes