### PR TITLE
 Support transports >> databridge config namespace

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/AgentHolder.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/AgentHolder.java
@@ -197,7 +197,7 @@ public class AgentHolder {
         if (transportConf != null) {
             LinkedHashMap dataBridgeConfig = ((LinkedHashMap) transportConf.get(DATABRIDGE_CONFIG_NAMESPACE));
             if (dataBridgeConfig != null) {
-                LinkedHashMap senderConf = ((LinkedHashMap)dataBridgeConfig.get(DATABRIDGE_SENDER_CONFIG_NAMESPACE));
+                LinkedHashMap senderConf = ((LinkedHashMap) dataBridgeConfig.get(DATABRIDGE_SENDER_CONFIG_NAMESPACE));
                 if (senderConf != null) {
                     dataAgentsConfiguration = DataAgentConfigurationFileResolver.
                             resolveAndSetDataAgentConfiguration(senderConf);
@@ -208,7 +208,7 @@ public class AgentHolder {
                 dataAgentsConfiguration = new DataAgentsConfiguration();
             }
 
-        } else if (configProvider. getConfigurationObject(DATA_AGENT_CONFIG_NAMESPACE) != null) {
+        } else if (configProvider.getConfigurationObject(DATA_AGENT_CONFIG_NAMESPACE) != null) {
             dataAgentsConfiguration = DataAgentConfigurationFileResolver.
                     resolveAndSetDataAgentConfiguration
                             ((LinkedHashMap) configProvider.

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/util/DataEndpointConstants.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/util/DataEndpointConstants.java
@@ -44,5 +44,8 @@ public class DataEndpointConstants {
     public static final String ASYNC_STRATEGY = "async";
 
     public static final String DATA_AGENT_CONFIG_NAMESPACE = "data.agent.config";
+    public static final String TRANSPORTS_NAMESPACE = "transports";
+    public static final String DATABRIDGE_CONFIG_NAMESPACE = "databridge";
+    public static final String DATABRIDGE_SENDER_CONFIG_NAMESPACE = "senderConfigurations";
 
 }

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/DataPublisherTestCase2.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/DataPublisherTestCase2.java
@@ -1,0 +1,291 @@
+/*
+*  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.carbon.databridge.agent.test;
+
+
+import org.apache.log4j.Logger;
+import org.testng.AssertJUnit;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.databridge.agent.AgentHolder;
+import org.wso2.carbon.databridge.agent.DataPublisher;
+import org.wso2.carbon.databridge.agent.exception.DataEndpointAgentConfigurationException;
+import org.wso2.carbon.databridge.agent.exception.DataEndpointAuthenticationException;
+import org.wso2.carbon.databridge.agent.exception.DataEndpointConfigurationException;
+import org.wso2.carbon.databridge.agent.exception.DataEndpointException;
+import org.wso2.carbon.databridge.agent.test.binary.BinaryTestServer;
+import org.wso2.carbon.databridge.commons.exception.MalformedStreamDefinitionException;
+import org.wso2.carbon.databridge.commons.exception.TransportException;
+import org.wso2.carbon.databridge.commons.utils.DataBridgeCommonsUtils;
+import org.wso2.carbon.databridge.core.exception.DataBridgeException;
+import org.wso2.carbon.databridge.core.exception.StreamDefinitionStoreException;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Datapublisher Test Case.
+ */
+public class DataPublisherTestCase2 {
+    private static final Logger log = Logger.getLogger(DataPublisherTestCase2.class);
+    private static final String STREAM_NAME = "org.wso2.esb.MediatorStatistics";
+    private static final String VERSION = "1.0.0";
+    private BinaryTestServer testServer;
+    private String agentConfigFileName = "data.agent.config2.yaml";
+
+    private static final String STREAM_DEFN = "{" +
+            "  'name':'" + STREAM_NAME + "'," +
+            "  'version':'" + VERSION + "'," +
+            "  'nickName': 'Stock Quote Information'," +
+            "  'description': 'Some Desc'," +
+            "  'tags':['foo', 'bar']," +
+            "  'metaData':[" +
+            "          {'name':'ipAdd','type':'STRING'}" +
+            "  ]," +
+            "  'payloadData':[" +
+            "          {'name':'symbol','type':'STRING'}," +
+            "          {'name':'price','type':'DOUBLE'}," +
+            "          {'name':'volume','type':'INT'}," +
+            "          {'name':'max','type':'DOUBLE'}," +
+            "          {'name':'min','type':'Double'}" +
+            "  ]" +
+            "}";
+
+    @BeforeClass
+    public static void init() {
+        DataPublisherTestUtil.setKeyStoreParams();
+        DataPublisherTestUtil.setTrustStoreParams();
+    }
+
+    @AfterClass
+    public static void stop() throws DataEndpointAuthenticationException, DataEndpointAgentConfigurationException,
+            TransportException, DataEndpointException, DataEndpointConfigurationException {
+        DataPublisher dataPublisher = new DataPublisher("Binary", "tcp://localhost:9687",
+                "ssl://localhost:9787", "admin", "admin");
+        dataPublisher.shutdownWithAgent();
+    }
+
+    private synchronized void startServer(int port, int securePort) throws DataBridgeException,
+            StreamDefinitionStoreException, MalformedStreamDefinitionException, IOException {
+        testServer = new BinaryTestServer("databridge.config2.yaml");
+        testServer.start(port, securePort);
+        testServer.addStreamDefinition(STREAM_DEFN);
+    }
+
+    @Test
+    public void overLoadPublishWithArbitraryElementsofEvent() throws DataEndpointAuthenticationException,
+            DataEndpointAgentConfigurationException, TransportException, DataEndpointException,
+            DataEndpointConfigurationException, MalformedStreamDefinitionException, DataBridgeException,
+            StreamDefinitionStoreException, IOException {
+        startServer(9661, 9761);
+        AgentHolder.setConfigPath(DataPublisherTestUtil.getDataAgentConfigPath(agentConfigFileName));
+        String hostName = DataPublisherTestUtil.LOCAL_HOST;
+
+        DataPublisher dataPublisher = new DataPublisher("Binary", "tcp://" + hostName + ":9661",
+                "ssl://" + hostName + ":9761", "admin", "admin");
+
+        String streamID = DataBridgeCommonsUtils.generateStreamId(STREAM_NAME, VERSION);
+        Object[] metaData = new Object[]{"127.0.0.1"};
+        Object[] correlationData = null;
+        Object[] payLoad = new Object[]{"WSO2", 123.4, 2, 12.4, 1.3};
+        Map<String, String> arbitrary = new HashMap<String, String>();
+        arbitrary.put("test", "testValue");
+        arbitrary.put("test1", "test123");
+
+        int numberOfEventsSent = 1000;
+        for (int i = 0; i < numberOfEventsSent; i++) {
+            dataPublisher.publish(streamID, metaData, correlationData, payLoad, arbitrary);
+        }
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            log.error("Thread sleep interrupted.", e);
+        }
+        dataPublisher.shutdown();
+        AssertJUnit.assertEquals(numberOfEventsSent, testServer.getNumberOfEventsReceived());
+        testServer.resetReceivedEvents();
+        testServer.stop();
+    }
+
+    @Test
+    public void nonBlockingPublishTestOverLoad() throws DataEndpointAuthenticationException,
+            DataEndpointAgentConfigurationException, TransportException, DataEndpointException,
+            DataEndpointConfigurationException, MalformedStreamDefinitionException, DataBridgeException,
+            StreamDefinitionStoreException, IOException {
+        startServer(9219, 9319);
+        AgentHolder.setConfigPath(DataPublisherTestUtil.getDataAgentConfigPath(agentConfigFileName));
+        String hostName = DataPublisherTestUtil.LOCAL_HOST;
+
+        DataPublisher dataPublisher = new DataPublisher("Binary", "tcp://" + hostName + ":9219",
+                "ssl://" + hostName + ":9319", "admin", "admin");
+
+        String streamID = DataBridgeCommonsUtils.generateStreamId(STREAM_NAME, VERSION);
+        Object[] metaData = new Object[]{"127.0.0.1"};
+        Object[] correlationData = null;
+        Object[] payLoad = new Object[]{"WSO2", 123.4, 2, 12.4, 1.3};
+        long timeout = 1000;
+
+        int numberOfEventsSent = 1000;
+        for (int i = 0; i < numberOfEventsSent; i++) {
+            dataPublisher.tryPublish(streamID, metaData, correlationData, payLoad, timeout);
+        }
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            log.error("Thread sleep interrupted.", e);
+        }
+        dataPublisher.shutdown();
+        AssertJUnit.assertEquals(numberOfEventsSent, testServer.getNumberOfEventsReceived());
+        testServer.resetReceivedEvents();
+        testServer.stop();
+    }
+
+    @Test
+    public void nonBlockingPublishTestOverLoadWithArbitaryElementsOfEvent() throws DataEndpointAuthenticationException,
+            DataEndpointAgentConfigurationException, TransportException, DataEndpointException,
+            DataEndpointConfigurationException, MalformedStreamDefinitionException, DataBridgeException,
+            StreamDefinitionStoreException, IOException {
+        startServer(9629, 9729);
+        AgentHolder.setConfigPath(DataPublisherTestUtil.getDataAgentConfigPath(agentConfigFileName));
+        String hostName = DataPublisherTestUtil.LOCAL_HOST;
+
+        DataPublisher dataPublisher = new DataPublisher("Binary", "tcp://" + hostName + ":9629",
+                "ssl://" + hostName + ":9729", "admin", "admin");
+
+        String streamID = DataBridgeCommonsUtils.generateStreamId(STREAM_NAME, VERSION);
+        Object[] metaData = new Object[]{"127.0.0.1"};
+        Object[] correlationData = null;
+        Object[] payLoad = new Object[]{"WSO2", 123.4, 2, 12.4, 1.3};
+        Map<String, String> arbitrary = new HashMap<String, String>();
+        arbitrary.put("test", "testValue");
+        arbitrary.put("test1", "test123");
+        int numberOfEventsSent = 1000;
+        for (int i = 0; i < numberOfEventsSent; i++) {
+            dataPublisher.tryPublish(streamID, metaData, correlationData, payLoad, arbitrary);
+        }
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            log.error("Thread sleep interrupted.", e);
+        }
+        dataPublisher.shutdown();
+        AssertJUnit.assertEquals(numberOfEventsSent, testServer.getNumberOfEventsReceived());
+        testServer.resetReceivedEvents();
+        testServer.stop();
+    }
+
+    @Test
+    public void nonBlockingPublishTestOverLoadWithTimeStampAndArbitaryElementsOfEvent() throws
+            DataEndpointAuthenticationException, DataEndpointAgentConfigurationException,
+            TransportException, DataEndpointException, DataEndpointConfigurationException,
+            MalformedStreamDefinitionException, DataBridgeException, StreamDefinitionStoreException, IOException {
+        startServer(9699, 9799);
+        AgentHolder.setConfigPath(DataPublisherTestUtil.getDataAgentConfigPath(agentConfigFileName));
+        String hostName = DataPublisherTestUtil.LOCAL_HOST;
+
+        DataPublisher dataPublisher = new DataPublisher("Binary", "tcp://" + hostName + ":9699",
+                "ssl://" + hostName + ":9799", "admin", "admin");
+
+        String streamID = DataBridgeCommonsUtils.generateStreamId(STREAM_NAME, VERSION);
+        Long timeStamp = System.currentTimeMillis();
+        Object[] metaData = new Object[]{"127.0.0.1"};
+        Object[] correlationData = null;
+        Object[] payLoad = new Object[]{"WSO2", 123.4, 2, 12.4, 1.3};
+        Map<String, String> arbitrary = new HashMap<String, String>();
+        arbitrary.put("test", "testValue");
+        arbitrary.put("test1", "test123");
+
+        int numberOfEventsSent = 1000;
+        for (int i = 0; i < numberOfEventsSent; i++) {
+            dataPublisher.tryPublish(streamID, timeStamp, metaData, correlationData, payLoad, arbitrary);
+        }
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            log.error("Thread sleep interrupted.", e);
+        }
+        dataPublisher.shutdown();
+        AssertJUnit.assertEquals(numberOfEventsSent, testServer.getNumberOfEventsReceived());
+        testServer.resetReceivedEvents();
+        testServer.stop();
+    }
+
+    @Test
+    public void nonBlockingPublishTestWithTimeOut() throws DataEndpointAuthenticationException,
+            DataEndpointAgentConfigurationException, TransportException, DataEndpointException,
+            DataEndpointConfigurationException, MalformedStreamDefinitionException, DataBridgeException,
+            StreamDefinitionStoreException, IOException {
+        startServer(9129, 9130);
+        AgentHolder.setConfigPath(DataPublisherTestUtil.getDataAgentConfigPath(agentConfigFileName));
+        String hostName = DataPublisherTestUtil.LOCAL_HOST;
+
+        DataPublisher dataPublisher = new DataPublisher("Binary", "tcp://" + hostName + ":9129",
+                "ssl://" + hostName + ":9130", "admin", "admin");
+
+        String streamID = DataBridgeCommonsUtils.generateStreamId(STREAM_NAME, VERSION);
+        Long timeStamp = System.currentTimeMillis();
+        Object[] metaData = new Object[]{"127.0.0.1"};
+        Object[] correlationData = null;
+        Object[] payLoad = new Object[]{"WSO2", 123.4, 2, 12.4, 1.3};
+        long timeout = 1000;
+
+        int numberOfEventsSent = 1000;
+        for (int i = 0; i < numberOfEventsSent; i++) {
+            dataPublisher.tryPublish(streamID, timeStamp, metaData, correlationData, payLoad, timeout);
+        }
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            log.error("Thread sleep interrupted.", e);
+        }
+        dataPublisher.shutdown();
+        AssertJUnit.assertEquals(numberOfEventsSent, testServer.getNumberOfEventsReceived());
+        testServer.resetReceivedEvents();
+        testServer.stop();
+    }
+
+    @Test(expectedExceptions = DataEndpointConfigurationException.class)
+    public void endpointValidityCheck1() throws DataEndpointAuthenticationException,
+            DataEndpointAgentConfigurationException, TransportException, DataEndpointException,
+            DataEndpointConfigurationException {
+
+        AgentHolder.setConfigPath(DataPublisherTestUtil.getDataAgentConfigPath(agentConfigFileName));
+        String hostName = DataPublisherTestUtil.LOCAL_HOST;
+
+        DataPublisher dataPublisher = new DataPublisher("Binary",
+                "{tcp://" + hostName + ":9129|tcp://" + hostName + ":9229,tcp://" + hostName + ":9229}",
+                "{ssl://" + hostName + ":9130,ssl://" + hostName + ":9230}", "admin", "admin");
+
+    }
+
+    @Test(expectedExceptions = DataEndpointConfigurationException.class)
+    public void endpointValidityCheck2() throws DataEndpointAuthenticationException,
+            DataEndpointAgentConfigurationException, TransportException, DataEndpointException,
+            DataEndpointConfigurationException {
+
+        AgentHolder.setConfigPath(DataPublisherTestUtil.getDataAgentConfigPath(agentConfigFileName));
+        String hostName = DataPublisherTestUtil.LOCAL_HOST;
+
+        DataPublisher dataPublisher = new DataPublisher("Binary",
+                "{tcp://" + hostName + ":9129|tcp://" + hostName + ":9229}",
+                "{ssl://" + hostName + ":9130}", "admin", "admin");
+
+    }
+}

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/DataPublisherTestUtil.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/DataPublisherTestUtil.java
@@ -78,7 +78,7 @@ public class DataPublisherTestUtil {
         return filePath.getAbsolutePath() + File.separator + fileName;
     }
 
-    public static String getDataBridgeConfigPath() {
+    public static String getDataBridgeConfigPath(String configFileName) {
         File filePath = new File("src" + File.separator + "test" + File.separator + "resources");
         if (!filePath.exists()) {
             filePath = new File("components" + File.separator + "data-bridge" + File.separator +
@@ -91,7 +91,7 @@ public class DataPublisherTestUtil {
         if (!filePath.exists()) {
             filePath = new File("test" + File.separator + "resources");
         }
-        return filePath.getAbsolutePath() + File.separator + "databridge.config.yaml";
+        return filePath.getAbsolutePath() + File.separator + configFileName;
     }
 
 }

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/binary/BinaryTestServer.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/binary/BinaryTestServer.java
@@ -44,11 +44,20 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Binary Test Server.
  */
 public class BinaryTestServer {
+    String configFileName;
     Logger log = LoggerFactory.getLogger(BinaryTestServer.class);
     BinaryDataReceiver binaryDataReceiver;
     InMemoryStreamDefinitionStore streamDefinitionStore;
     AtomicInteger numberOfEventsReceived;
     RestarterThread restarterThread;
+
+    public BinaryTestServer() {
+        this.configFileName = "databridge.config.yaml";
+    }
+
+    public BinaryTestServer(String configFileName) {
+        this.configFileName = configFileName;
+    }
 
     public void startTestServer() throws DataBridgeException, InterruptedException, IOException {
         BinaryTestServer testServer = new BinaryTestServer();
@@ -95,7 +104,7 @@ public class BinaryTestServer {
             public void destroyContext(AgentSession agentSession) {
 
             }
-        }, streamDefinitionStore, DataPublisherTestUtil.getDataBridgeConfigPath());
+        }, streamDefinitionStore, DataPublisherTestUtil.getDataBridgeConfigPath(configFileName));
 
         BinaryDataReceiverConfiguration dataReceiverConfiguration = new BinaryDataReceiverConfiguration(securePort,
                 tcpPort);

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/thrift/ThriftTestServer.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/thrift/ThriftTestServer.java
@@ -95,7 +95,7 @@ public class ThriftTestServer {
             public void destroyContext(AgentSession agentSession) {
 
             }
-        }, streamDefinitionStore, DataPublisherTestUtil.getDataBridgeConfigPath());
+        }, streamDefinitionStore, DataPublisherTestUtil.getDataBridgeConfigPath("databridge.config.yaml"));
 
         thriftDataReceiver = new ThriftDataReceiver(receiverPort, databridge);
 

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/resources/data.agent.config2.yaml
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/resources/data.agent.config2.yaml
@@ -1,0 +1,133 @@
+################################################################################
+#   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Configuration of the Data Agents - to publish events through databridge
+transports:
+  databridge:
+    senderConfigurations:
+    # Data agent configurations
+    # THIS IS A MANDATORY FIELD
+      agents:
+      -
+          # Data agent configuration
+        agentConfiguration:
+            # Data agent name
+            # THIS IS A MANDATORY FIELD
+          name: Thrift
+            # Data endpoint class
+            # THIS IS A MANDATORY FIELD
+          dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.thrift.ThriftDataEndpoint
+            # Data publisher strategy
+          publishingStrategy: async
+            # Trust store path
+          trustStorePath: ''
+            # Trust store password
+          trustStorePassword: ''
+            # Queue Size
+          queueSize: 32768
+            # Batch Size
+          batchSize: 200
+            # Core pool size
+          corePoolSize: 5
+            # Socket timeout in milliseconds
+          socketTimeoutMS: 30000
+            # Maximum pool size
+          maxPoolSize: 10
+            # Keep alive time in pool
+          keepAliveTimeInPool: 20
+            # Reconnection interval
+          reconnectionInterval: 30
+            # Max transport pool size
+          maxTransportPoolSize: 250
+            # Max idle connections
+          maxIdleConnections: 250
+            # Eviction time interval
+          evictionTimePeriod: 5500
+            # Min idle time in pool
+          minIdleTimeInPool: 5000
+            # Secure max transport pool size
+          secureMaxTransportPoolSize: 250
+            # Secure max idle connections
+          secureMaxIdleConnections: 250
+            # secure eviction time period
+          secureEvictionTimePeriod: 5500
+            # Secure min idle time in pool
+          secureMinIdleTimeInPool: 5000
+            # SSL enabled protocols
+          sslEnabledProtocols: TLSv1,TLSv1.1,TLSv1.2
+            # Ciphers
+          ciphers: SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA
+      -
+          # Data agent configuration
+        agentConfiguration:
+            # Data agent name
+            # THIS IS A MANDATORY FIELD
+          name: Binary
+            # Data endpoint class
+            # THIS IS A MANDATORY FIELD
+          dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.binary.BinaryDataEndpoint
+            # Data publisher strategy
+          publishingStrategy: async
+            # Trust store path
+          trustStorePath: ''
+            # Trust store password
+          trustStorePassword: ''
+            # Queue Size
+          queueSize: 32768
+            # Batch Size
+          batchSize: 200
+            # Core pool size
+          corePoolSize: 5
+            # Socket timeout in milliseconds
+          socketTimeoutMS: 30000
+            # Maximum pool size
+          maxPoolSize: 10
+            # Keep alive time in pool
+          keepAliveTimeInPool: 20
+            # Reconnection interval
+          reconnectionInterval: 30
+            # Max transport pool size
+          maxTransportPoolSize: 250
+            # Max idle connections
+          maxIdleConnections: 250
+            # Eviction time interval
+          evictionTimePeriod: 5500
+            # Min idle time in pool
+          minIdleTimeInPool: 5000
+            # Secure max transport pool size
+          secureMaxTransportPoolSize: 250
+            # Secure max idle connections
+          secureMaxIdleConnections: 250
+            # secure eviction time period
+          secureEvictionTimePeriod: 5500
+            # Secure min idle time in pool
+          secureMinIdleTimeInPool: 5000
+            # SSL enabled protocols
+          sslEnabledProtocols: TLSv1,TLSv1.1,TLSv1.2
+            # Ciphers
+          ciphers: SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA
+
+wso2.securevault:
+  secretRepository:
+    type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
+    parameters:
+      privateKeyAlias: wso2carbon
+      keystoreLocation: src/test/resources/wso2carbon.jks
+      secretPropertiesFile: src/test/resources/secrets.properties
+  masterKeyReader:
+    type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
+    parameters:
+      masterKeyReaderFile: src/test/resources/master-keys.yaml

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/resources/databridge.config2.yaml
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/resources/databridge.config2.yaml
@@ -1,0 +1,71 @@
+################################################################################
+#   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Configuration used for the databridge communication
+transports:
+  databridge:
+    listenerConfigurations:
+        # No of worker threads to consume events
+        # THIS IS A MANDATORY FIELD
+      workerThreads: 10
+        # Maximum amount of messages that can be queued internally in MB
+        # THIS IS A MANDATORY FIELD
+      maxEventBufferCapacity: 10000000
+        # Queue size; the maximum number of events that can be stored in the queue
+        # THIS IS A MANDATORY FIELD
+      eventBufferSize: 2000
+        # Session Timeout value in mins
+        # THIS IS A MANDATORY FIELD
+      clientTimeoutMin: 30
+        # Data receiver configurations
+        # THIS IS A MANDATORY FIELD
+      dataReceivers:
+      -
+          # Data receiver configuration
+        dataReceiver:
+            # Data receiver type
+            # THIS IS A MANDATORY FIELD
+          type: Thrift
+            # Data receiver properties
+          properties:
+            tcpPort: '7611'
+            sslPort: '7711'
+
+      -
+          # Data receiver configuration
+        dataReceiver:
+            # Data receiver type
+            # THIS IS A MANDATORY FIELD
+          type: Binary
+            # Data receiver properties
+          properties:
+            tcpPort: '9611'
+            sslPort: '9711'
+            tcpReceiverThreadPoolSize: '100'
+            sslReceiverThreadPoolSize: '100'
+            hostName: 0.0.0.0
+
+wso2.securevault:
+  secretRepository:
+    type: org.wso2.carbon.secvault.repository.DefaultSecretRepository
+    parameters:
+      privateKeyAlias: wso2carbon
+      keystoreLocation: src/test/resources/wso2carbon.jks
+      secretPropertiesFile: src/test/resources/secrets.properties
+  masterKeyReader:
+    type: org.wso2.carbon.secvault.reader.DefaultMasterKeyReader
+    parameters:
+      masterKeyReaderFile: src/test/resources/master-keys.yaml

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/resources/testng.xml
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/resources/testng.xml
@@ -32,6 +32,7 @@
             <class name="org.wso2.carbon.databridge.agent.test.thrift.ServerOfflineThriftTest"/>
             <class name="org.wso2.carbon.databridge.agent.test.DataBrigdeWorkerTestCase"/>
             <class name="org.wso2.carbon.databridge.agent.test.DataPublisherTestCase"/>
+            <class name="org.wso2.carbon.databridge.agent.test.DataPublisherTestCase2"/>
             <class name="org.wso2.carbon.databridge.agent.test.LegacyDataPublisherTestCase"/>
             <class name="org.wso2.carbon.databridge.agent.test.DataPublisherWithDefaultsTestCase"/>
         </classes>

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/DataBridge.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/DataBridge.java
@@ -500,9 +500,16 @@ public class DataBridge implements DataBridgeSubscriberService, DataBridgeReceiv
         try {
             if (Files.exists(databridgeConfigPath)) {
                 ConfigProvider configProvider = ConfigProviderFactory.getConfigProvider(databridgeConfigPath);
-                dataBridgeConfiguration = DatabridgeConfigurationFileResolver.
-                        resolveAndSetDatabridgeConfiguration((LinkedHashMap) configProvider.
-                                getConfigurationObject(DataBridgeConstants.DATABRIDGE_CONFIG_NAMESPACE));
+                LinkedHashMap transportsConf = (LinkedHashMap) configProvider.
+                        getConfigurationObject(DataBridgeConstants.TRANSPORTS_NAMESPACE);
+                if (transportsConf != null) {
+                    dataBridgeConfiguration = DatabridgeConfigurationFileResolver
+                            .resolveTransportsNamespaceConfiguration(transportsConf);
+                } else {
+                    dataBridgeConfiguration = DatabridgeConfigurationFileResolver.
+                            resolveAndSetDatabridgeConfiguration((LinkedHashMap) configProvider.
+                                    getConfigurationObject(DataBridgeConstants.DATABRIDGE_CONFIG_NAMESPACE));
+                }
                 return dataBridgeConfiguration;
             } else {
                 log.error("Cannot find data bridge configuration file : " + configPath);

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/conf/DatabridgeConfigurationFileResolver.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/conf/DatabridgeConfigurationFileResolver.java
@@ -23,10 +23,26 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import static org.wso2.carbon.databridge.core.internal.utils.DataBridgeConstants.DATABRIDGE_LISTENER_CONFIG_NAMESPACE;
+import static org.wso2.carbon.databridge.core.internal.utils.DataBridgeConstants.STREAMLINED_DATABRIDGE_CONFIG_NAMESPACE;
+
 /**
  * Resolves the databridge configuration file.
  */
 public class DatabridgeConfigurationFileResolver {
+
+    public static DataBridgeConfiguration resolveTransportsNamespaceConfiguration(LinkedHashMap transportsConf) {
+        DataBridgeConfiguration dataBridgeConfiguration = new DataBridgeConfiguration();
+
+        LinkedHashMap dataBridgeConfig = ((LinkedHashMap) transportsConf.get(STREAMLINED_DATABRIDGE_CONFIG_NAMESPACE));
+        if (dataBridgeConfig != null) {
+            LinkedHashMap listenerConf = ((LinkedHashMap) dataBridgeConfig.get(DATABRIDGE_LISTENER_CONFIG_NAMESPACE));
+            if (listenerConf != null) {
+                return resolveAndSetDatabridgeConfiguration(listenerConf);
+            }
+        }
+        return dataBridgeConfiguration;
+    }
 
     public static DataBridgeConfiguration resolveAndSetDatabridgeConfiguration(LinkedHashMap databridgeConfigHashMap) {
         DataBridgeConfiguration dataBridgeConfiguration = new DataBridgeConfiguration();

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/utils/DataBridgeConstants.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/utils/DataBridgeConstants.java
@@ -36,4 +36,7 @@ public final class DataBridgeConstants {
     public static final String STREAM_DEFINITIONS_ELEMENT = "streamDefinitions";
 
     public static final String DATABRIDGE_CONFIG_NAMESPACE = "databridge.config";
+    public static final String TRANSPORTS_NAMESPACE = "transports";
+    public static final String STREAMLINED_DATABRIDGE_CONFIG_NAMESPACE = "databridge";
+    public static final String DATABRIDGE_LISTENER_CONFIG_NAMESPACE = "listenerConfigurations";
 }

--- a/components/osgi-tests/pom.xml
+++ b/components/osgi-tests/pom.xml
@@ -194,47 +194,6 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>post-integration-test</phase>
-                                <configuration>
-                                    <target xmlns:jacoco="antlib:org.jacoco.ant">
-                                        <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml">
-                                            <classpath path="${project.build.directory}" />
-                                        </taskdef>
-                                        <!-- OSGi Test coverage only enabled for org.wso2.carbon.stream.core module-->
-                                        <jacoco:report>
-                                            <executiondata>
-                                                <file file="${project.build.directory}/jacoco.exec" />
-                                            </executiondata>
-                                            <structure name="Carbon Analytics Common OSGi Tests">
-                                                <classfiles>
-                                                    <fileset dir="../data-bridge/org.wso2.carbon.databridge.core/target/classes" />
-                                                </classfiles>
-                                                <sourcefiles encoding="UTF-8">
-                                                    <fileset dir="../data-bridge/org.wso2.carbon.databridge.core/src" />
-                                                </sourcefiles>
-                                            </structure>
-                                            <html destdir="${project.build.directory}/coverage-reports" />
-                                        </jacoco:report>
-                                    </target>
-                                </configuration>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.jacoco</groupId>
-                                <artifactId>org.jacoco.ant</artifactId>
-                                <version>${org.jacoco.ant.version}</version>
-                            </dependency>
-                        </dependencies>
-                    </plugin>
-                    <plugin>
                         <groupId>org.ops4j.pax.exam</groupId>
                         <artifactId>maven-paxexam-plugin</artifactId>
                         <version>1.2.4</version>


### PR DESCRIPTION
## Purpose
$subject
```
transports:
  databridge:
  # Configuration used for the databridge communication
    listenerConfigurations:
      # No of worker threads to consume events
      # THIS IS A MANDATORY FIELD
      workerThreads: 10
      # Maximum amount of messages that can be queued internally in MB
      # THIS IS A MANDATORY FIELD
      maxEventBufferCapacity: 10000000

. 
.
.
    senderConfigurations:
    # Configuration of the Data Agents - to publish events through databridge
      agents:
        - # Data agent configuration
          agentConfiguration:
            # Data agent name
            # THIS IS A MANDATORY FIELD

```

## Goals
Streamline config as discussed in https://groups.google.com/forum/?hl=en#!topic/siddhi-dev/j3W4mA8jjQ8

## Approach
As in 22c21ac

## Documentation
N/A as it is backward compatible

## Automation tests
 - Unit tests - Attached herewith
 - Integration tests - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
