### PR TITLE
fix the issue of session variable not instantiated per tenant.

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
@@ -57,7 +57,7 @@ public class EmailEventAdapter implements OutputEventAdapter {
 
     private static final Log log = LogFactory.getLog(EmailEventAdapter.class);
     private static ThreadPoolExecutor threadPoolExecutor;
-    private static Session session;
+    private Session session;
     private OutputEventAdapterConfiguration eventAdapterConfiguration;
     private Map<String, String> globalProperties;
     private int tenantId;


### PR DESCRIPTION
In the current implementation although EmailEventAdapter is created per tenant. There is a static session variable that holds the created session[1]. Due to this only one session will be created for all tenants.

[1].https://github.com/Buddhimah/carbon-analytics-common/blob/5b1f34d6fb91339974e549b76768629e450c01c1/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java#L60