### PR TITLE
Null check receiverManager is available before starts polling schedule

### DIFF
--- a/components/event-processor-manager/org.wso2.carbon.event.processor.manager.core/src/main/java/org/wso2/carbon/event/processor/manager/core/internal/CarbonEventManagementService.java
+++ b/components/event-processor-manager/org.wso2.carbon.event.processor.manager.core/src/main/java/org/wso2/carbon/event/processor/manager/core/internal/CarbonEventManagementService.java
@@ -228,7 +228,8 @@ public class CarbonEventManagementService implements EventManagementService {
         if ((mode == Mode.SingleNode || isWorkerNode ) && receiverManager != null) {
             receiverManager.start();
         }
-        if ((mode == Mode.Distributed || mode == Mode.HA) && isWorkerNode || mode == Mode.SingleNode) {
+        if (((mode == Mode.Distributed || mode == Mode.HA) && isWorkerNode || mode == Mode.SingleNode)
+                && receiverManager != null)  {
             executorService.schedule(new Runnable() {
                 @Override
                 public void run() {

--- a/pom.xml
+++ b/pom.xml
@@ -1500,7 +1500,7 @@
         <carbon.analytics.common.version>5.2.9-SNAPSHOT</carbon.analytics.common.version>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.5.0-m3</carbon.kernel.version>
+        <carbon.kernel.version>4.5.0-alpha3</carbon.kernel.version>
         <carbon.kernel.feature.version>4.5.0</carbon.kernel.feature.version>
         <!--<carbon.kernel.imp.pkg.version>[4.3.0, 4.4.0)</carbon.kernel.imp.pkg.version>-->
         <securevault.wso2.version>1.1.3</securevault.wso2.version>


### PR DESCRIPTION
## Purpose
> Fix https://github.com/wso2/product-is/issues/6189

WSO2 IS pack don't have the event receiver module in the system. So it causes an error in when starting the server.