### PR TITLE
pseudo implementation added for interfaces - 5.10 Fix

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
@@ -57,7 +57,7 @@ public class EmailEventAdapter implements OutputEventAdapter {
 
     private static final Log log = LogFactory.getLog(EmailEventAdapter.class);
     private static ThreadPoolExecutor threadPoolExecutor;
-    private static Session session;
+    private Session session;
     private OutputEventAdapterConfiguration eventAdapterConfiguration;
     private Map<String, String> globalProperties;
     private int tenantId;

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/EventPublisherService.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/EventPublisherService.java
@@ -14,6 +14,8 @@
  */
 package org.wso2.carbon.event.publisher.core;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.databridge.commons.StreamDefinition;
 import org.wso2.carbon.event.publisher.core.config.EventPublisherConfiguration;
 import org.wso2.carbon.event.publisher.core.config.EventPublisherConfigurationFile;
@@ -24,6 +26,7 @@ import java.util.List;
 public interface EventPublisherService {
 
 
+    static final Log log = LogFactory.getLog(EventPublisherService.class);
     /**
      * Method used to add a new event publisher configuration
      *
@@ -197,5 +200,15 @@ public interface EventPublisherService {
      */
     public String getEventPublisherName(String eventPublisherConfigXml)
             throws EventPublisherConfigurationException;
+
+    /**
+     * Add the Event Publisher Configuration.
+     *
+     * @param eventPublisherConfiguration Event Publisher Configuration, as a configuration object.
+     * @throws EventPublisherConfigurationException
+     */
+    public default void addEventPublisherConfiguration(EventPublisherConfiguration eventPublisherConfiguration)
+            throws EventPublisherConfigurationException {
+    }
 
 }

--- a/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/EventStreamService.java
+++ b/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/EventStreamService.java
@@ -93,4 +93,14 @@ public interface EventStreamService {
 
     public void publish(Event event);
 
+    /**
+     * Add the Event Stream Configuration.
+     *
+     * @param eventStreamConfiguration Event Stream Configuration, as a configuration object.
+     * @throws EventStreamConfigurationException
+     */
+    public default void addEventStreamConfig(EventStreamConfiguration eventStreamConfiguration)
+            throws EventStreamConfigurationException {
+    }
+
 }


### PR DESCRIPTION
## Purpose
> Fix : wso2/product-is#6146

- In the current implementation although EmailEventAdapter is created per tenant. There is a static session variable that holds the created session[1]. Due to this only one session will be created for all tenants.

- Although CarbonEventPublisherService which implements EventPublisherService has a method addEventPublisherService we cannot use that using the osgi serviced ue to that is not available in the interface EventPublisherService. The same issue resolved for EventStreamService


[1].https://github.com/Buddhimah/carbon-analytics-common/blob/5b1f34d6fb91339974e549b76768629e450c01c1/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java#L60

## Approach

- Made the session variable as an instance variable

- created psudo implementations in interfaces

