### PR TITLE
Tenant Wise Configurations For The Email Sender Fixed for IS-5.10

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapterFactory.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapterFactory.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 /**
@@ -58,7 +59,47 @@ public class EmailEventAdapterFactory extends OutputEventAdapterFactory {
 
     @Override
     public List<Property> getStaticPropertyList() {
-        return null;
+
+        List<Property> staticpropertyList = new ArrayList<>();
+
+        Property smtplUserName = new Property(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_USER);
+        smtplUserName.setDisplayName(resourceBundle.getString(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_USER));
+        smtplUserName.setRequired(false);
+
+        Property smtpPassword = new Property(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_PASSWORD);
+        smtpPassword.setDisplayName(resourceBundle.getString(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_PASSWORD));
+        smtpPassword.setRequired(false);
+
+        Property smtpAuth = new Property(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_AUTH);
+        smtpAuth.setDisplayName(resourceBundle.getString(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_AUTH));
+        smtpAuth.setRequired(false);
+
+        Property smtpFrom = new Property(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_FROM);
+        smtpFrom.setDisplayName(resourceBundle.getString(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_FROM));
+        smtpFrom.setRequired(false);
+
+        Property smtpHost = new Property(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_HOST);
+        smtpHost.setDisplayName(resourceBundle.getString(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_HOST));
+        smtpHost.setRequired(false);
+
+        Property smtpPort = new Property(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_PORT);
+        smtpPort.setDisplayName(resourceBundle.getString(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_PORT));
+        smtpPort.setRequired(false);
+
+        Property startTLSEnable = new Property(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_STARTTLS_ENABLE);
+        startTLSEnable.setDisplayName(
+                resourceBundle.getString(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_STARTTLS_ENABLE));
+        startTLSEnable.setRequired(false);
+
+        staticpropertyList.add(smtplUserName);
+        staticpropertyList.add(smtpPassword);
+        staticpropertyList.add(smtpAuth);
+        staticpropertyList.add(smtpFrom);
+        staticpropertyList.add(smtpHost);
+        staticpropertyList.add(smtpPort);
+        staticpropertyList.add(startTLSEnable);
+
+        return staticpropertyList;
     }
 
     @Override

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapterFactory.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapterFactory.java
@@ -91,6 +91,14 @@ public class EmailEventAdapterFactory extends OutputEventAdapterFactory {
                 resourceBundle.getString(EmailEventAdapterConstants.ADAPTER_EMAIL_SMTP_STARTTLS_ENABLE));
         startTLSEnable.setRequired(false);
 
+        Property senderSignature = new Property(EmailEventAdapterConstants.MAIL_SMTP_SIGNATURE);
+        startTLSEnable.setDisplayName(resourceBundle.getString(EmailEventAdapterConstants.MAIL_SMTP_SIGNATURE));
+        startTLSEnable.setRequired(false);
+
+        Property replyToAddress = new Property(EmailEventAdapterConstants.MAIL_SMTP_REPLY_TO);
+        startTLSEnable.setDisplayName(resourceBundle.getString(EmailEventAdapterConstants.MAIL_SMTP_REPLY_TO));
+        startTLSEnable.setRequired(false);
+
         staticpropertyList.add(smtplUserName);
         staticpropertyList.add(smtpPassword);
         staticpropertyList.add(smtpAuth);
@@ -98,6 +106,8 @@ public class EmailEventAdapterFactory extends OutputEventAdapterFactory {
         staticpropertyList.add(smtpHost);
         staticpropertyList.add(smtpPort);
         staticpropertyList.add(startTLSEnable);
+        staticpropertyList.add(senderSignature);
+        staticpropertyList.add(replyToAddress);
 
         return staticpropertyList;
     }

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/internal/util/EmailEventAdapterConstants.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/internal/util/EmailEventAdapterConstants.java
@@ -60,5 +60,11 @@ public class EmailEventAdapterConstants {
     public static final String MAIL_TEXT_PLAIN = "text/plain";
     public static final String MAIL_TEXT_HTML = "text/html";
 
+    /**
+     * SMTP optional property constants.
+     */
+    public static final String MAIL_SMTP_REPLY_TO = "mail.smtp.replyTo";
+    public static final String MAIL_SMTP_SIGNATURE = "mail.smtp.signature";
+
 
 }

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/internal/util/EmailEventAdapterConstants.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/internal/util/EmailEventAdapterConstants.java
@@ -28,6 +28,13 @@ public class EmailEventAdapterConstants {
     public static final String ADAPTER_MESSAGE_EMAIL_SUBJECT = "email.subject";
     public static final String APAPTER_MESSAGE_EMAIL_TYPE = "email.type";
     public static final String ADAPTER_MESSAGE_EMAIL_TYPE_HINT = "emailType.hint";
+    public static final String ADAPTER_EMAIL_SMTP_PORT = "mail.smtp.port";
+    public static final String ADAPTER_EMAIL_SMTP_USER  = "mail.smtp.user";
+    public static final String ADAPTER_EMAIL_SMTP_PASSWORD  = "mail.smtp.password";
+    public static final String ADAPTER_EMAIL_SMTP_FROM  = "mail.smtp.from";
+    public static final String ADAPTER_EMAIL_SMTP_HOST  = "mail.smtp.host";
+    public static final String ADAPTER_EMAIL_SMTP_AUTH  = "mail.smtp.auth";
+    public static final String ADAPTER_EMAIL_SMTP_STARTTLS_ENABLE  = "mail.smtp.starttls.enable";
     public static final String MIN_THREAD_NAME = "minThread";
     public static final String MAX_THREAD_NAME = "maxThread";
     public static final String ADAPTER_KEEP_ALIVE_TIME_NAME = "keepAliveTimeInMillis";

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/resources/org/wso2/carbon/event/output/adapter/email/i18n/Resources.properties
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/resources/org/wso2/carbon/event/output/adapter/email/i18n/Resources.properties
@@ -21,6 +21,13 @@ emailAddress.hint=Register publisher for multiple email IDs' separated by ","
 email.subject=Subject
 email.type=Email Type
 emailType.hint= Select the email format to be sent
+mail.smtp.user = User Name
+mail.smtp.password = Password
+mail.smtp.from = From Email
+mail.smtp.host = SMTP host
+mail.smtp.port = SMTP host port
+mail.smtp.auth = SMTP auth
+mail.smtp.starttls.enable = start TLS enable
 
 
 

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/resources/org/wso2/carbon/event/output/adapter/email/i18n/Resources.properties
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/resources/org/wso2/carbon/event/output/adapter/email/i18n/Resources.properties
@@ -28,6 +28,8 @@ mail.smtp.host = SMTP host
 mail.smtp.port = SMTP host port
 mail.smtp.auth = SMTP auth
 mail.smtp.starttls.enable = start TLS enable
+mail.smtp.replyTo = replyTo email
+mail.smtp.signature = sender email signature
 
 
 

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/test/java/org/wso2/carbon/event/output/adapter/email/EmailOutputAdaptorTestCase.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/test/java/org/wso2/carbon/event/output/adapter/email/EmailOutputAdaptorTestCase.java
@@ -329,6 +329,8 @@ public class EmailOutputAdaptorTestCase {
         globalProperties.put("jobQueueSize", "10000");
         globalProperties.put("mail.smtp.host", "smtp.gmail.com");
         globalProperties.put("minThread", "8");
+        globalProperties.put("mail.smtp.replyTo", "efgh@gmail.com");
+        globalProperties.put("mail.smtp.signature", "efgh");
         adapterFactory.createEventAdapter(eventAdapterConfiguration, globalProperties);
     }
 }

--- a/components/event-publisher/org.wso2.carbon.event.output.adapter.core/src/main/java/org/wso2/carbon/event/output/adapter/core/internal/CarbonOutputEventAdapterService.java
+++ b/components/event-publisher/org.wso2.carbon.event.output.adapter.core/src/main/java/org/wso2/carbon/event/output/adapter/core/internal/CarbonOutputEventAdapterService.java
@@ -118,6 +118,10 @@ public class CarbonOutputEventAdapterService implements OutputEventAdapterServic
         }
         Map<String, String> globalProperties = OutputEventAdapterServiceValueHolder.getGlobalAdapterConfigs().
                 getAdapterConfig(outputEventAdapterConfiguration.getType()).getGlobalPropertiesAsMap();
+        if (outputEventAdapterConfiguration.getStaticProperties() != null) {
+            overrideGlobalPropertiesWithTenantProperties(globalProperties,
+                    outputEventAdapterConfiguration.getStaticProperties());
+        }
         eventAdapters.put(outputEventAdapterConfiguration.getName(), new OutputAdapterRuntime(adapterFactory.
                 createEventAdapter(outputEventAdapterConfiguration, globalProperties), outputEventAdapterConfiguration.getName()));
     }
@@ -202,6 +206,23 @@ public class CarbonOutputEventAdapterService implements OutputEventAdapterServic
                 }
             }
             throw new OutputEventAdapterException("Adopter with name'" + outputAdapterName + "' not found");
+    }
+
+    /**
+     * This method override the global properties if tenant properties are present.
+     *
+     * @param globalProps global properties from output-event-adapters.xml.
+     * @param tenantProps tenant wise properties configured in tenant wise Publishers.
+     * @param tenantProps
+     */
+    private void overrideGlobalPropertiesWithTenantProperties(Map<String, String> globalProps,
+            Map<String, String> tenantProps) {
+
+        for (String key : tenantProps.keySet()) {
+            if (globalProps.containsKey(key) && tenantProps.get(key) != null) {
+                globalProps.put(key, tenantProps.get(key));
+            }
+        }
     }
 
 }

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/EventPublisherService.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/EventPublisherService.java
@@ -211,4 +211,14 @@ public interface EventPublisherService {
             throws EventPublisherConfigurationException {
     }
 
+    /**
+     * Get Event Publisher Configuration from xml.
+     *
+     * @param eventPublisherConfigurationXml EventPublisher configuration in xml.
+     */
+    public default EventPublisherConfiguration getEventPublisherConfiguration(String eventPublisherConfigurationXml)
+            throws EventPublisherConfigurationException {
+        return null;
+    }
+
 }

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/EventPublisherService.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/EventPublisherService.java
@@ -21,6 +21,7 @@ import org.wso2.carbon.event.publisher.core.config.EventPublisherConfiguration;
 import org.wso2.carbon.event.publisher.core.config.EventPublisherConfigurationFile;
 import org.wso2.carbon.event.publisher.core.exception.EventPublisherConfigurationException;
 
+import java.io.InputStream;
 import java.util.List;
 
 public interface EventPublisherService {
@@ -214,11 +215,34 @@ public interface EventPublisherService {
     /**
      * Get Event Publisher Configuration from xml.
      *
-     * @param eventPublisherConfigurationXml EventPublisher configuration in xml.
+     * @param eventPublisherConfiguration EventPublisher configuration as input stream.
      */
-    public default EventPublisherConfiguration getEventPublisherConfiguration(String eventPublisherConfigurationXml)
+    public default EventPublisherConfiguration getEventPublisherConfiguration(InputStream eventPublisherConfiguration)
             throws EventPublisherConfigurationException {
         return null;
+    }
+
+    /**
+     * Add the Event Publisher Configuration File.
+     *
+     * @param eventPublisherConfigurationFile Event Publisher Configuration File, as a configuration file object.
+     * @param tenantId                        Tenant ID.
+     * @throws EventPublisherConfigurationException
+     */
+    public default void addEventPublisherConfigurationFile(
+            EventPublisherConfigurationFile eventPublisherConfigurationFile, int tenantId)
+            throws EventPublisherConfigurationException {
+    }
+
+    /**
+     * Remove Event Publisher Configuration File.
+     *
+     * @param fileName EventPublisher File name.
+     * @param tenantId Tenant ID.
+     * @throws EventPublisherConfigurationException
+     */
+    public default void removeEventPublisherConfigurationFile(String fileName, int tenantId) {
+
     }
 
 }

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/CarbonEventPublisherService.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/CarbonEventPublisherService.java
@@ -83,6 +83,27 @@ public class CarbonEventPublisherService implements EventPublisherService {
 
     }
 
+    public EventPublisherConfiguration getEventPublisherConfiguration(String eventPublisherConfigurationXml)
+            throws EventPublisherConfigurationException {
+
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        EventPublisherConfiguration eventPublisherConfigurationObject;
+        try {
+            OMElement omElement = AXIOMUtil.stringToOM(eventPublisherConfigurationXml);
+            omElement.build();
+            EventPublisherConfigurationHelper.validateEventPublisherConfiguration(omElement);
+            String mappingType = EventPublisherConfigurationHelper.getOutputMappingType(omElement);
+            if (mappingType != null) {
+                eventPublisherConfigurationObject = EventPublisherConfigurationBuilder.getEventPublisherConfiguration(omElement, mappingType, true, tenantId);
+            } else {
+                throw new EventPublisherConfigurationException("Mapping type of the Event Publisher cannot be null");
+            }
+        } catch (XMLStreamException e) {
+            throw new EventPublisherConfigurationException("Error while building XML configuration :" + e.getMessage(), e);
+        }
+        return eventPublisherConfigurationObject;
+    }
+
     @Override
     public void deployEventPublisherConfiguration(
             String eventPublisherConfigXml)

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/CarbonEventPublisherService.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/CarbonEventPublisherService.java
@@ -96,12 +96,14 @@ public class CarbonEventPublisherService implements EventPublisherService {
             EventPublisherConfigurationHelper.validateEventPublisherConfiguration(omElement);
             String mappingType = EventPublisherConfigurationHelper.getOutputMappingType(omElement);
             if (mappingType != null) {
-                eventPublisherConfigurationObject = EventPublisherConfigurationBuilder.getEventPublisherConfiguration(omElement, mappingType, true, tenantId);
+                eventPublisherConfigurationObject = EventPublisherConfigurationBuilder
+                        .getEventPublisherConfiguration(omElement, mappingType, true, tenantId);
             } else {
                 throw new EventPublisherConfigurationException("Mapping type of the Event Publisher cannot be null");
             }
         } catch (XMLStreamException e) {
-            throw new EventPublisherConfigurationException("Error while building XML configuration :" + e.getMessage(), e);
+            throw new EventPublisherConfigurationException("Error while building XML configuration :" + e.getMessage(),
+                    e);
         }
         return eventPublisherConfigurationObject;
     }

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/CarbonEventPublisherService.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/CarbonEventPublisherService.java
@@ -17,6 +17,7 @@ package org.wso2.carbon.event.publisher.core.internal;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
+import org.apache.axis2.dataretrieval.DataRetrievalUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -43,6 +44,7 @@ import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.registry.core.utils.RegistryUtils;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -83,13 +85,13 @@ public class CarbonEventPublisherService implements EventPublisherService {
 
     }
 
-    public EventPublisherConfiguration getEventPublisherConfiguration(String eventPublisherConfigurationXml)
+    public EventPublisherConfiguration getEventPublisherConfiguration(InputStream eventPublisherConfiguration)
             throws EventPublisherConfigurationException {
 
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
         EventPublisherConfiguration eventPublisherConfigurationObject;
         try {
-            OMElement omElement = AXIOMUtil.stringToOM(eventPublisherConfigurationXml);
+            OMElement omElement = DataRetrievalUtil.convertToOMElement(eventPublisherConfiguration);
             omElement.build();
             EventPublisherConfigurationHelper.validateEventPublisherConfiguration(omElement);
             String mappingType = EventPublisherConfigurationHelper.getOutputMappingType(omElement);


### PR DESCRIPTION
Fix: wso2/product-is#6146

email event adapter configurations which are in the output-event-adapters.xml to the EventPublisher.xml. Global configurations will be there in the output-event-adapters.xml. If someone needs to add a different SMTP connection to some tenant then those SMTP configurations should be added to EmailPublisher.xml corresponding to that tenant.

thread pool properties do not need to add per tenant. These configurations will be hot deployed. If these configurations are there they will replace the global configurations. And they will be used for the email sending as per tenant.