### PR TITLE
Add ability to get all the roles specific to a tenant

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/api/IdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/api/IdPClient.java
@@ -40,6 +40,15 @@ public interface IdPClient {
     List<Role> getAllRoles() throws IdPClientException;
 
     /**
+     * This returns all the roles available in the user store for the given tenant.
+     *
+     * @param username name of the user
+     * @return List of {Role} objects
+     * @throws IdPClientException thrown when an error occurred when retrieving roles
+     */
+    List<Role> getAllRolesOfTenant(String username) throws IdPClientException;
+
+    /**
      * This returns the admin role of the user store.
      *
      * @return {Role}

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
@@ -182,6 +182,12 @@ public class ExternalIdPClient implements IdPClient {
     }
 
     @Override
+    public List<Role> getAllRolesOfTenant(String username) throws IdPClientException {
+        // Since there is no tenant concept in External IdP Client, all the roles are returned.
+        return getAllRoles();
+    }
+
+    @Override
     public Role getAdminRole() throws IdPClientException {
         Response response = scimServiceStub.getAllGroups();
         if (response == null) {

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/local/LocalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/local/LocalIdPClient.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.analytics.idp.client.core.api.IdPClient;
 import org.wso2.carbon.analytics.idp.client.core.exception.AuthenticationException;
+import org.wso2.carbon.analytics.idp.client.core.exception.IdPClientException;
 import org.wso2.carbon.analytics.idp.client.core.models.Role;
 import org.wso2.carbon.analytics.idp.client.core.models.User;
 import org.wso2.carbon.analytics.idp.client.core.utils.IdPClientConstants;
@@ -70,6 +71,12 @@ public class LocalIdPClient implements IdPClient {
     @Override
     public List<Role> getAllRoles() {
         return rolesList;
+    }
+
+    @Override
+    public List<Role> getAllRolesOfTenant(String username) throws IdPClientException {
+        // Since there is no tenant concept in Local IdP Client, all the roles are returned.
+        return getAllRoles();
     }
 
     @Override

--- a/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/PermissionProvider.java
+++ b/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/PermissionProvider.java
@@ -112,5 +112,15 @@ public interface PermissionProvider {
      */
     List<Role> getGrantedRoles(Permission permission) throws PermissionException;
 
+    /**
+     * Get list of roles in a tenant which has a permission granted.
+     *
+     * @param permission
+     * @param username
+     * @return
+     * @throws PermissionException
+     */
+    List<Role> getGrantedRolesOfTenant(Permission permission, String username) throws PermissionException;
+
     List<Role> getGrantedRoles(String permissionID) throws PermissionException;
 }

--- a/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/internal/impl/DefaultPermissionProvider.java
+++ b/components/permission-provider/org.wso2.carbon.analytics.permissions/src/main/java/org/wso2/carbon/analytics/permissions/internal/impl/DefaultPermissionProvider.java
@@ -244,6 +244,11 @@ public class DefaultPermissionProvider implements PermissionProvider {
      */
     @Override
     public List<Role> getGrantedRoles(Permission permission) throws PermissionException {
+        return getGrantedRolesOfTenant(permission, null);
+    }
+
+    @Override
+    public List<Role> getGrantedRolesOfTenant(Permission permission, String username) throws PermissionException {
         if (log.isDebugEnabled()) {
             log.debug("Get roles assigned for " + permission);
         }
@@ -251,7 +256,12 @@ public class DefaultPermissionProvider implements PermissionProvider {
         // Create a map out of all the roles with role Id as the key. This map will be used to get the role name.
         Map<String, org.wso2.carbon.analytics.idp.client.core.models.Role> roleMap = new HashMap<>();
         try {
-            List<org.wso2.carbon.analytics.idp.client.core.models.Role> allRoles = idPClient.getAllRoles();
+            List<org.wso2.carbon.analytics.idp.client.core.models.Role> allRoles;
+            if (username != null) {
+                allRoles = idPClient.getAllRolesOfTenant(username);
+            } else {
+                allRoles = idPClient.getAllRoles();
+            }
             for (org.wso2.carbon.analytics.idp.client.core.models.Role role : allRoles) {
                 roleMap.put(role.getId(), role);
             }


### PR DESCRIPTION
## Purpose
Add the ability to get all the roles specific to a tenant

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes