### PR TITLE
Improving event adapters xml template

### DIFF
--- a/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/templates/repository/conf/output-event-adapters.xml.j2
+++ b/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/templates/repository/conf/output-event-adapters.xml.j2
@@ -100,6 +100,12 @@
         <property key="mail.smtp.auth">{{output_adapter.email.enable_authentication}}</property>
         <property key="mail.smtp.signature">{{output_adapter.email.signature}}</property>
         <property key="mail.smtp.replyTo">{{output_adapter.email.reply_to}}</property>
+        {% if output_adapter.email.custom_properties is defined %}
+        <!-- Custom Properties -->
+        {% for property_name,property_value in output_adapter.email.custom_properties.items() %}
+        <property key="{{property_name}}">{{property_value}}</property>
+        {% endfor %}
+        {% endif %}
         <!-- Thread Pool Related Properties -->
         <property key="minThread">8</property>
         <property key="maxThread">100</property>


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-is/issues/7472

Improving the email adapter template to facilitate custom properties in the following format.

`<property key="mail.smtp.user">{{output_adapter.email.username}}</property>`

To configure properties, use the following sample config.

```
[output_adapter.email.custom_properties]
"mail.smtp.signature"="sominda@test.com"
```

Support Fix: https://github.com/wso2-support/carbon-analytics-common/pull/168

## Approach
Defining a `for loop` to read configs other than the ones which are already defined.
