### PR TITLE
New method signature to pass params

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/IdPClientConstants.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/IdPClientConstants.java
@@ -43,6 +43,7 @@ public class IdPClientConstants {
     public static final String REMEMBER_ME = "Remember_Me";
     public static final String APP_ID = "App_Id";
     public static final String RETURN_LOGOUT_PROPERTIES = "returnLogoutProperties";
+    public static final String DOMAIN = "Domain";
 
     public static final String USERNAME = "Username";
     public static final String PASSWORD = "Password";

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/ExternalIdPClient.java
@@ -464,6 +464,11 @@ public class ExternalIdPClient implements IdPClient {
         }
     }
 
+    public Map<String, String> authCodeLogin(String appContext, String code, Map<String, String> properties)
+            throws IdPClientException {
+        throw new IdPClientException("Not implemented yet.");
+    }
+
     @Override
     public Map<String, String> logout(Map<String, String> properties) throws IdPClientException {
         String token = properties.get(IdPClientConstants.ACCESS_TOKEN);


### PR DESCRIPTION
## Purpose

APIM Analytics IDP client extends ExternalIDPClient. APIM Analytics requires header params passed in properties to support custom url for api-cloud. Hence implementing a new method. 