### PR TITLE
Add Kafka090 Publisher

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>event-output-adapters</artifactId>
+        <groupId>org.wso2.carbon.analytics-common</groupId>
+        <version>5.1.61-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.event.output.adapter.kafka090</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Event Output Kafka090 Adaptor Module</name>
+    <description>org.wso2.carbon.event.output.adaptor.kafka090 provides the back-end
+        functionality of output kafka090 adaptor
+    </description>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.event.output.adapter.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.axis2.transport</groupId>
+            <artifactId>axis2-transport-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.10</artifactId>
+            <version>0.9.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-scr-descriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            org.wso2.carbon.event.output.adapter.kafka090.internal,
+                            org.wso2.carbon.event.output.adapter.kafka090.internal.*
+                        </Private-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.event.output.adapter.kafka090.internal,
+                            !org.wso2.carbon.event.output.adapter.kafka090.internal.*,
+                            org.wso2.carbon.event.output.adapter.kafka090.*,
+                        </Export-Package>
+                        <Import-Package>
+                            org.wso2.carbon.event.output.adapter.core,
+                            org.wso2.carbon.event.output.adapter.core.*,
+                            !javax.xml.namespace,
+                            javax.xml.namespace; version=0.0.0,
+                            *;resolution:=optional,
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+    </properties>
+
+
+</project>

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/pom.xml
@@ -81,15 +81,16 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <suiteXmlFiles>
-                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
-                    </suiteXmlFiles>
-                </configuration>
-            </plugin>
+            <!--Commenting this out as there are no tests-->
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-surefire-plugin</artifactId>-->
+                <!--<configuration>-->
+                    <!--<suiteXmlFiles>-->
+                        <!--<suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>-->
+                    <!--</suiteXmlFiles>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/src/main/java/org/wso2/carbon/event/output/adapter/kafka090/KafkaEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/src/main/java/org/wso2/carbon/event/output/adapter/kafka090/KafkaEventAdapter.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.event.output.adapter.kafka090;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.event.output.adapter.core.EventAdapterUtil;
+import org.wso2.carbon.event.output.adapter.core.OutputEventAdapter;
+import org.wso2.carbon.event.output.adapter.core.OutputEventAdapterConfiguration;
+import org.wso2.carbon.event.output.adapter.core.exception.OutputEventAdapterException;
+import org.wso2.carbon.event.output.adapter.core.exception.TestConnectionNotSupportedException;
+import org.wso2.carbon.event.output.adapter.kafka090.internal.util.KafkaEventAdapterConstants;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class KafkaEventAdapter implements OutputEventAdapter {
+
+    private static final Log log = LogFactory.getLog(KafkaEventAdapter.class);
+    private static ThreadPoolExecutor threadPoolExecutor;
+    private OutputEventAdapterConfiguration eventAdapterConfiguration;
+    private Map<String, String> globalProperties;
+    private org.apache.kafka.clients.producer.Producer<String, Object> producer;
+    private int tenantId;
+
+    public KafkaEventAdapter(OutputEventAdapterConfiguration eventAdapterConfiguration,
+                             Map<String, String> globalProperties) {
+        this.eventAdapterConfiguration = eventAdapterConfiguration;
+        this.globalProperties = globalProperties;
+    }
+
+    @Override
+    public void init() throws OutputEventAdapterException {
+
+        tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+
+        //ThreadPoolExecutor will be assigned  if it is null
+        if (threadPoolExecutor == null) {
+            int minThread;
+            int maxThread;
+            int jobQueSize;
+            long defaultKeepAliveTime;
+
+            //If global properties are available those will be assigned else constant values will be assigned
+            if (globalProperties.get(KafkaEventAdapterConstants.ADAPTER_MIN_THREAD_POOL_SIZE_NAME) != null) {
+                minThread = Integer.parseInt(globalProperties.get(KafkaEventAdapterConstants.ADAPTER_MIN_THREAD_POOL_SIZE_NAME));
+            } else {
+                minThread = KafkaEventAdapterConstants.ADAPTER_MIN_THREAD_POOL_SIZE;
+            }
+
+            if (globalProperties.get(KafkaEventAdapterConstants.ADAPTER_MAX_THREAD_POOL_SIZE_NAME) != null) {
+                maxThread = Integer.parseInt(globalProperties.get(KafkaEventAdapterConstants.ADAPTER_MAX_THREAD_POOL_SIZE_NAME));
+            } else {
+                maxThread = KafkaEventAdapterConstants.ADAPTER_MAX_THREAD_POOL_SIZE;
+            }
+
+            if (globalProperties.get(KafkaEventAdapterConstants.ADAPTER_KEEP_ALIVE_TIME_NAME) != null) {
+                defaultKeepAliveTime = Integer.parseInt(globalProperties.get(
+                        KafkaEventAdapterConstants.ADAPTER_KEEP_ALIVE_TIME_NAME));
+            } else {
+                defaultKeepAliveTime = KafkaEventAdapterConstants.DEFAULT_KEEP_ALIVE_TIME_IN_MILLIS;
+            }
+
+            if (globalProperties.get(KafkaEventAdapterConstants.ADAPTER_EXECUTOR_JOB_QUEUE_SIZE_NAME) != null) {
+                jobQueSize = Integer.parseInt(globalProperties.get(
+                        KafkaEventAdapterConstants.ADAPTER_EXECUTOR_JOB_QUEUE_SIZE_NAME));
+            } else {
+                jobQueSize = KafkaEventAdapterConstants.ADAPTER_EXECUTOR_JOB_QUEUE_SIZE;
+            }
+
+            threadPoolExecutor = new ThreadPoolExecutor(minThread, maxThread, defaultKeepAliveTime,
+                    TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(jobQueSize), new ThreadFactoryBuilder()
+                    .setNameFormat("KafkaOutput090-" + eventAdapterConfiguration.getName() + "-executor-thread-%d").build());
+        }
+
+    }
+
+    @Override
+    public void testConnect() throws TestConnectionNotSupportedException {
+        throw new TestConnectionNotSupportedException("Test connection is not available");
+    }
+
+    @Override
+    public void connect() {
+        Map<String, String> staticProperties = eventAdapterConfiguration.getStaticProperties();
+
+        String kafkaConnect = staticProperties.get(KafkaEventAdapterConstants.ADAPTOR_META_BROKER_LIST);
+        String optionalConfigs = staticProperties.get(KafkaEventAdapterConstants.ADAPTOR_OPTIONAL_CONFIGURATION_PROPERTIES);
+
+        Properties props = new Properties();
+        props.put("bootstrap.servers", kafkaConnect);
+        props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+
+        readOptionalConfigs(props, optionalConfigs);
+
+        producer = new KafkaProducer<String,Object>(props);
+        log.info("Kafka producer created.");
+
+    }
+
+    public static void readOptionalConfigs(Properties props, String optionalConfigs) {
+        if (optionalConfigs != null && !optionalConfigs.isEmpty()) {
+            String[] optionalProperties = optionalConfigs.split(KafkaEventAdapterConstants.HEADER_SEPARATOR);
+            if (optionalProperties.length > 0) {
+                for (String header : optionalProperties) {
+                    try {
+                        String[] configPropertyWithValue = header.split(KafkaEventAdapterConstants.ENTRY_SEPARATOR, 2);
+                        props.put(configPropertyWithValue[0], configPropertyWithValue[1]);
+                    } catch (Exception e) {
+                        log.warn("Optional property '" + header + "' is not defined in the correct format.", e);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void publish(Object message, Map<String, String> dynamicProperties) {
+
+        //By default auto.create.topics.enable is true, then no need to create topic explicitly
+        String topic = dynamicProperties.get(KafkaEventAdapterConstants.ADAPTOR_PUBLISH_TOPIC);
+        try {
+            threadPoolExecutor.submit(new KafkaSender(topic, message));
+        } catch (RejectedExecutionException e) {
+            EventAdapterUtil.logAndDrop(eventAdapterConfiguration.getName(), message, "Job queue is full", e, log, tenantId);
+        }
+    }
+
+    @Override
+    public void disconnect() {
+        //close producer
+        if (producer != null) {
+            producer.close();
+        }
+    }
+
+    @Override
+    public void destroy() {
+        //not required
+    }
+
+    @Override
+    public boolean isPolled() {
+        return false;
+    }
+
+
+    class KafkaSender implements Runnable {
+
+        String topic;
+        Object message;
+
+        KafkaSender(String topic, Object message) {
+            this.topic = topic;
+            this.message = message;
+        }
+
+        @Override
+        public void run() {
+            try {
+                producer.send(new ProducerRecord<String,Object>(topic, message));
+            } catch (Throwable e) {
+                log.error("Unexpected error when sending event via Kafka Output Adatper 090:" + e.getMessage(), e);
+            }
+        }
+    }
+
+}

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/src/main/java/org/wso2/carbon/event/output/adapter/kafka090/KafkaEventAdapterFactory.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/src/main/java/org/wso2/carbon/event/output/adapter/kafka090/KafkaEventAdapterFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.event.output.adapter.kafka090;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.event.output.adapter.core.*;
+import org.wso2.carbon.event.output.adapter.kafka090.internal.util.KafkaEventAdapterConstants;
+
+import java.util.*;
+
+/**
+ * The kafka event adapter factory class to create a kafka output adapter
+ */
+public class KafkaEventAdapterFactory extends OutputEventAdapterFactory {
+    private static final Log log = LogFactory.getLog(KafkaEventAdapterFactory.class);
+
+    private ResourceBundle resourceBundle =
+            ResourceBundle.getBundle("org.wso2.carbon.event.output.adapter.kafka090.i18n.Resources", Locale.getDefault());
+
+    @Override
+    public String getType() {
+        return KafkaEventAdapterConstants.ADAPTOR_TYPE_KAFKA;
+    }
+
+    @Override
+    public List<String> getSupportedMessageFormats() {
+        List<String> supportedMessageFormats = new ArrayList<String>();
+        supportedMessageFormats.add(MessageType.TEXT);
+        supportedMessageFormats.add(MessageType.XML);
+        supportedMessageFormats.add(MessageType.JSON);
+        return supportedMessageFormats;
+    }
+
+    @Override
+    public List<Property> getStaticPropertyList() {
+        List<Property> propertyList = new ArrayList<Property>();
+
+        //set Kafka Connect of broker
+        Property webKafkaConnect = new Property(KafkaEventAdapterConstants.ADAPTOR_META_BROKER_LIST);
+        webKafkaConnect.setDisplayName(resourceBundle.getString(KafkaEventAdapterConstants.ADAPTOR_META_BROKER_LIST));
+        webKafkaConnect.setHint(resourceBundle.getString(KafkaEventAdapterConstants.ADAPTOR_META_BROKER_LIST_HINT));
+        webKafkaConnect.setRequired(true);
+        propertyList.add(webKafkaConnect);
+
+        Property optionConfigProperties = new Property(KafkaEventAdapterConstants.ADAPTOR_OPTIONAL_CONFIGURATION_PROPERTIES);
+        optionConfigProperties.setDisplayName(
+                resourceBundle.getString(KafkaEventAdapterConstants.ADAPTOR_OPTIONAL_CONFIGURATION_PROPERTIES));
+        optionConfigProperties.setHint(resourceBundle.getString(KafkaEventAdapterConstants.ADAPTOR_OPTIONAL_CONFIGURATION_PROPERTIES_HINT));
+        propertyList.add(optionConfigProperties);
+
+        return propertyList;
+
+    }
+
+    @Override
+    public List<Property> getDynamicPropertyList() {
+        List<Property> propertyList = new ArrayList<Property>();
+
+        //set Topic of broker
+        Property webTopic = new Property(KafkaEventAdapterConstants.ADAPTOR_PUBLISH_TOPIC);
+        webTopic.setDisplayName(resourceBundle.getString(KafkaEventAdapterConstants.ADAPTOR_PUBLISH_TOPIC));
+        webTopic.setRequired(true);
+        propertyList.add(webTopic);
+
+        return propertyList;
+    }
+
+    @Override
+    public String getUsageTips() {
+        return null;
+    }
+
+    @Override
+    public OutputEventAdapter createEventAdapter(OutputEventAdapterConfiguration eventAdapterConfiguration, Map<String,
+            String> globalProperties) {
+        return new KafkaEventAdapter(eventAdapterConfiguration, globalProperties);
+    }
+
+}

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/src/main/java/org/wso2/carbon/event/output/adapter/kafka090/internal/ds/KafkaEventAdapterServiceDS.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/src/main/java/org/wso2/carbon/event/output/adapter/kafka090/internal/ds/KafkaEventAdapterServiceDS.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.event.output.adapter.kafka090.internal.ds;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.wso2.carbon.event.output.adapter.core.OutputEventAdapterFactory;
+import org.wso2.carbon.event.output.adapter.kafka090.KafkaEventAdapterFactory;
+import org.wso2.carbon.utils.ConfigurationContextService;
+
+/**
+ *
+ * @scr.component name="output.Kafka090.EventAdaptorService.component" immediate="true"
+ * @scr.reference name="configurationcontext.service"
+ * interface="org.wso2.carbon.utils.ConfigurationContextService" cardinality="0..1"
+ * policy="dynamic" bind="setConfigurationContextService" unbind="unsetConfigurationContextService"
+ *
+ */
+public class KafkaEventAdapterServiceDS {
+
+    private static final Log log = LogFactory.getLog(KafkaEventAdapterServiceDS.class);
+
+    /**
+     * initialize the kafka service here service here.
+     *
+     * @param context
+     */
+    protected void activate(ComponentContext context) {
+
+        try {
+            OutputEventAdapterFactory testOutEventAdaptorFactory = new KafkaEventAdapterFactory();
+            context.getBundleContext().registerService(OutputEventAdapterFactory.class.getName(), testOutEventAdaptorFactory, null);
+            if (log.isDebugEnabled()) {
+                log.debug("Successfully deployed the output Kafka 090 adapter service");
+            }
+        } catch (RuntimeException e) {
+            log.error("Can not create the Kafka 090 output event adaptor service ", e);
+        }
+    }
+
+    protected void setConfigurationContextService(
+            ConfigurationContextService configurationContextService) {
+        KafkaEventAdapterServiceValueHolder.registerConfigurationContextService(configurationContextService);
+    }
+
+    protected void unsetConfigurationContextService(
+            ConfigurationContextService configurationContextService) {
+
+    }
+
+
+}

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/src/main/java/org/wso2/carbon/event/output/adapter/kafka090/internal/ds/KafkaEventAdapterServiceValueHolder.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/src/main/java/org/wso2/carbon/event/output/adapter/kafka090/internal/ds/KafkaEventAdapterServiceValueHolder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.event.output.adapter.kafka090.internal.ds;
+
+import org.wso2.carbon.utils.ConfigurationContextService;
+
+/**
+ * common place to hold some OSGI bundle references.
+ */
+public final class KafkaEventAdapterServiceValueHolder {
+
+    private static ConfigurationContextService configurationContextService;
+
+    private KafkaEventAdapterServiceValueHolder() {
+    }
+
+    public static void registerConfigurationContextService(
+            ConfigurationContextService configurationContextService) {
+        KafkaEventAdapterServiceValueHolder.configurationContextService = configurationContextService;
+    }
+
+    public static ConfigurationContextService getConfigurationContextService() {
+        return KafkaEventAdapterServiceValueHolder.configurationContextService;
+    }
+
+}

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/src/main/java/org/wso2/carbon/event/output/adapter/kafka090/internal/util/KafkaEventAdapterConstants.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/src/main/java/org/wso2/carbon/event/output/adapter/kafka090/internal/util/KafkaEventAdapterConstants.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.event.output.adapter.kafka090.internal.util;
+
+public class KafkaEventAdapterConstants {
+
+    private KafkaEventAdapterConstants() {
+    }
+
+    public static final int ADAPTER_MIN_THREAD_POOL_SIZE = 8;
+    public static final int ADAPTER_MAX_THREAD_POOL_SIZE = 100;
+    public static final int ADAPTER_EXECUTOR_JOB_QUEUE_SIZE = 2000;
+    public static final long DEFAULT_KEEP_ALIVE_TIME_IN_MILLIS = 20000;
+    public static final String ADAPTER_MIN_THREAD_POOL_SIZE_NAME = "minThread";
+    public static final String ADAPTER_MAX_THREAD_POOL_SIZE_NAME = "maxThread";
+    public static final String ADAPTER_KEEP_ALIVE_TIME_NAME = "keepAliveTimeInMillis";
+    public static final String ADAPTER_EXECUTOR_JOB_QUEUE_SIZE_NAME = "jobQueueSize";
+    public final static String ADAPTOR_TYPE_KAFKA = "kafka090";
+    public final static String ADAPTOR_PUBLISH_TOPIC = "topic";
+    public final static String ADAPTOR_META_BROKER_LIST = "meta.broker.list";
+    public final static String ADAPTOR_META_BROKER_LIST_HINT = "meta.broker.list.hint";
+    public final static String ADAPTOR_OPTIONAL_CONFIGURATION_PROPERTIES = "optional.configuration";
+    public final static String ADAPTOR_OPTIONAL_CONFIGURATION_PROPERTIES_HINT = "optional.configuration.hint";
+    public static final String HEADER_SEPARATOR = ",";
+    public static final String ENTRY_SEPARATOR = ":";
+
+
+}

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/src/main/resources/org/wso2/carbon/event/output/adapter/kafka090/i18n/Resources.properties
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.kafka090/src/main/resources/org/wso2/carbon/event/output/adapter/kafka090/i18n/Resources.properties
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+topic=Topic
+meta.broker.list=Meta Broker List
+meta.broker.list.hint=This is for bootstrapping and the producer will only use it for getting metadata. (eg - {host1:port1,host2:port2}, and the list can be a subset of brokers)
+optional.configuration=Optional Configuration Properties
+optional.configuration.hint=Define optional configuration properties (eg - {property_name1:property_value1, property_name2:property_value2 .. })

--- a/components/event-publisher/event-output-adapters/pom.xml
+++ b/components/event-publisher/event-output-adapters/pom.xml
@@ -38,6 +38,7 @@
         <module>org.wso2.carbon.event.output.adapter.logger</module>
         <module>org.wso2.carbon.event.output.adapter.email</module>
         <module>org.wso2.carbon.event.output.adapter.kafka</module>
+        <module>org.wso2.carbon.event.output.adapter.kafka090</module>
        <module>org.wso2.carbon.event.output.adapter.rdbms</module>
         <module>org.wso2.carbon.event.output.adapter.http</module>
         <module>org.wso2.carbon.event.output.adapter.soap</module>

--- a/components/event-receiver/event-input-adapters/org.wso2.carbon.event.input.adapter.kafka090/pom.xml
+++ b/components/event-receiver/event-input-adapters/org.wso2.carbon.event.input.adapter.kafka090/pom.xml
@@ -28,7 +28,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.event.input.adapter.kafka090</artifactId>
-  <version>5.1.3</version>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon - Event Input Kafka Adaptor Module</name>
     <description>org.wso2.carbon.event.input.adaptor.kafka090 provides the back-end

--- a/components/event-receiver/event-input-adapters/org.wso2.carbon.event.input.adapter.kafka090/pom.xml
+++ b/components/event-receiver/event-input-adapters/org.wso2.carbon.event.input.adapter.kafka090/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.analytics-common</groupId>
         <artifactId>event-input-adapters</artifactId>
-        <version>5.1.3</version>
+        <version>5.1.61-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Purpose
Add Kafka090 Publisher. This is the Kafka Publisher corresponding to the Kafka090 receiver introduced in https://github.com/wso2/carbon-analytics-common/pull/744
Similar to the Kafka090 Receiver, Kafka090 Event Publisher uses the new API introduced in Kafka Client v0.9.0.

## Goals
The built-in Kafka Publisher does not work when the kafka client is upgraded to v0.9.0 hence  Kafka090 Publisher is introduced.

## Approach
The Kafka090 Event Publisher uses the new API in Kafka Client v0.9.0, in order to achieve this.

## User stories
As a user, I need to be able to create a Kafka Receiver by specifying the Bootstrap URL instead of the ZK URL. Furthermore, on the same DAS server, I need to create a Kafka Publisher.

## Release note
Add Kafka090 Event Publisher: This Kafka Event Publisher uses the new API introduced in Kafka Client v0.9.0.

## Documentation
Following client jars are required to be put in <DAS_HOME>/repository/components/lib/
```
kafka-clients-0.9.0.0.jar	
kafka_2.11-0.9.0.0.jar		
metrics-core-2.2.0.jar		
scala-library-2.11.7.jar	
zkclient-0.7.jar		
zookeeper-3.4.6.jar
```
These jars can be found in the Apache Kafka_2.11-0.9.0.0 distribution, which can be downloaded from [here](https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.11-0.9.0.0.tgz).

The jars can be found in kafka_2.11-0.9.0.0/libs folder.

## Automation tests
Not available

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
Sample configuration given below:
```
<?xml version="1.0" encoding="UTF-8"?>
<eventPublisher name="KafkaPublisher" statistics="disable"
  trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
  <from streamName="test" version="1.0.0"/>
  <mapping customMapping="disable" type="text"/>
  <to eventAdapterType="kafka090">
    <property name="topic">test2</property>
    <property name="meta.broker.list">localhost:9092</property>
  </to>
</eventPublisher>
```

## Related PRs
https://github.com/wso2/carbon-analytics-common/pull/744

## Migrations (if applicable)
N/A

## Test environment
Tested with Kafka server version: 2.11-1.0.1 

java version "1.8.0_171"
Java(TM) SE Runtime Environment (build 1.8.0_171-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.171-b11, mixed mode)

Mac OS v10.13.1 (17B1003)