### PR TITLE
[5.2.x] [Output Event Adapter] Add custom output event adapter config

### DIFF
--- a/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/templates/repository/conf/output-event-adapters.xml.j2
+++ b/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/templates/repository/conf/output-event-adapters.xml.j2
@@ -151,4 +151,14 @@
         <property key="maxConnectionsPerHost">50</property>
     </adapterConfig>
 
+    {% for adapter in output_adapter.custom_output_adapter %}
+    {% if adapter.type is defined %}
+    <adapterConfig type="{{adapter.type}}">
+        {% for key,value in adapter.properties.items() %}
+        <property key="{{key}}">{{value}}</property>
+        {% endfor %}
+    </adapterConfig>
+    {% endif %}
+    {% endfor %}
+
 </outputEventAdaptersConfig>


### PR DESCRIPTION
$sub
Resolves https://github.com/wso2/product-is/issues/11554

**Issue** 
Need to add some config for custom output event adapter

**Approach**
- Improved j2 file to have one or more custom output event adapter
- Custom event adapter is only replaced in the template only if output adapter has a config named **type**


### Sample Configuration

**deployment.toml**
```
[[output_adapter.custom_output_adapter]]
type= "adapter_type_1"
[output_adapter.custom_output_adapter.properties]
"mail.smtp.from" = "sampe@gmail.com"
"mail.smtp.from.reply_to" = "noreply.sample@gmail.com"
"username" = "231"
"password" = ""


[[output_adapter.custom_output_adapter]]
type= "adapter_type_2"
[output_adapter.custom_output_adapter.properties]
"from_address" = "sampe2@gmail.com"
"reply_to" = "a@enel.com"
```
**output-event-adapter.xml.j2**
```
    {% for adapter in output_adapter.custom_output_adapter %}
    {% if adapter.type is defined %}  
    <adapterConfig type="{{adapter.type}}">
        {% for key,value in adapter.properties.items() %}
        <property key="{{key}}">{{value}}</property>
        {% endfor %}
    </adapterConfig>
    {% endif %}
    {% endfor %}
```
**output-event-adapter.xml**
```
    <adapterConfig type="adapter_type_1">
        <property key="mail.smtp.from">sampe@gmail.com</property>
        <property key="username">231</property>
        <property key="password"></property>
        <property key="mail.smtp.from.reply_to">noreply.sample@gmail.com</property>
    </adapterConfig>
  
    <adapterConfig type="adapter_type_2">
        <property key="from_address">sampe2@gmail.com</property>
        <property key="reply_to">a@enel.com</property>
    </adapterConfig>
```



