### PR TITLE
Support keystore config from deployment.yml

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/IdPClientConstants.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/IdPClientConstants.java
@@ -73,5 +73,14 @@ public class IdPClientConstants {
         public static final String INTERNAL_SERVER_ERROR = "Internal_Server_Error";
     }
 
+    /**
+     * SSL config constants.
+     */
+    public static class SSL {
+        public static final String KEY_STORE = "javax.net.ssl.keyStore";
+        public static final String KEY_STORE_PASSWORD = "javax.net.ssl.keyStorePassword";
+        public static final String TRUST_STORE = "javax.net.ssl.trustStore";
+        public static final String TRUST_STORE_PASSWORD = "javax.net.ssl.trustStorePassword";
+    }
 
 }

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/SSLConfig.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/SSLConfig.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.analytics.idp.client.core.utils;
 
 import org.wso2.carbon.analytics.idp.client.core.utils.config.SSLConfiguration;

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/SSLConfig.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/SSLConfig.java
@@ -1,0 +1,43 @@
+package org.wso2.carbon.analytics.idp.client.core.utils;
+
+import org.wso2.carbon.analytics.idp.client.core.utils.config.SSLConfiguration;
+import org.wso2.carbon.utils.StringUtils;
+
+/**
+ * SSL Configs.
+ */
+public class SSLConfig {
+
+    private boolean sslConfigsExistInConfigProvider = false;
+    private final String keyStorePassword;
+    private final String trustStorePassword;
+    private final String keyStoreLocation;
+    private final String trustStoreLocation;
+
+    public SSLConfig(SSLConfiguration sslConfiguration) {
+
+        this.keyStorePassword = sslConfiguration.getKeyStorePassword();
+        this.trustStorePassword = sslConfiguration.getTrustStorePassword();
+        this.keyStoreLocation = sslConfiguration.getKeyStoreLocation();
+        this.trustStoreLocation = sslConfiguration.getTrustStoreLocation();
+        if (!StringUtils.isNullOrEmptyAfterTrim(keyStorePassword)
+                && !StringUtils.isNullOrEmptyAfterTrim(keyStoreLocation)
+                && !StringUtils.isNullOrEmptyAfterTrim(trustStorePassword)
+                && !StringUtils.isNullOrEmptyAfterTrim(trustStoreLocation)) {
+            sslConfigsExistInConfigProvider = true;
+        }
+    }
+
+    public boolean isSSLConfigsExistInConfigProvider() {
+
+        return sslConfigsExistInConfigProvider;
+    }
+
+    public void exportSSLConfigsExistInConfigProvider() {
+
+        System.setProperty(IdPClientConstants.SSL.KEY_STORE_PASSWORD, this.keyStorePassword);
+        System.setProperty(IdPClientConstants.SSL.TRUST_STORE_PASSWORD, this.trustStorePassword);
+        System.setProperty(IdPClientConstants.SSL.KEY_STORE, this.keyStoreLocation);
+        System.setProperty(IdPClientConstants.SSL.TRUST_STORE, this.trustStoreLocation);
+    }
+}

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/config/SSLConfiguration.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/config/SSLConfiguration.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.analytics.idp.client.core.utils.config;
 
 import org.wso2.carbon.config.annotation.Configuration;

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/config/SSLConfiguration.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/core/utils/config/SSLConfiguration.java
@@ -1,0 +1,43 @@
+package org.wso2.carbon.analytics.idp.client.core.utils.config;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * SSL configurations.
+ */
+@Configuration(namespace = "ssl.configs", description = "SSL Configuration Parameters")
+public class SSLConfiguration {
+
+    @Element(description = "Keystore Password", required = true)
+    private String keyStorePassword = null;
+
+    @Element(description = "Keystore Location", required = true)
+    private String keyStoreLocation = null;
+
+    @Element(description = "Truststore Password")
+    private String trustStorePassword = null;
+
+    @Element(description = "Truststore Location")
+    private String trustStoreLocation = null;
+
+    public String getKeyStorePassword() {
+
+        return keyStorePassword;
+    }
+
+    public String getTrustStorePassword() {
+
+        return trustStorePassword;
+    }
+
+    public String getTrustStoreLocation() {
+
+        return trustStoreLocation;
+    }
+
+    public String getKeyStoreLocation() {
+
+        return keyStoreLocation;
+    }
+}


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-ei/issues/5444

## Goals

You can define the following configurations in the deployment.yaml files in each runtime

```yaml
# SSL configuration           
ssl.configs:
  keyStorePassword : ${sec:net.ssl.keyStorePassword}
  keyStoreLocation : ${carbon.home}/resources/security/wso2carbon.jks
  trustStorePassword : ${sec:net.ssl.trustStorePassword}
  trustStoreLocation : ${carbon.home}/resources/security/client-truststore.jks
```