### PR TITLE
Introduce enableLineBreak Static Property to LoggerEventAdapter

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.logger/src/main/java/org/wso2/carbon/event/output/adapter/logger/LoggerEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.logger/src/main/java/org/wso2/carbon/event/output/adapter/logger/LoggerEventAdapter.java
@@ -62,10 +62,14 @@ public final class LoggerEventAdapter implements OutputEventAdapter {
             uniqueIdentification = eventAdapterConfiguration.getName();
         }
 
+        Boolean enableLineBreak = Boolean.parseBoolean(eventAdapterConfiguration.getStaticProperties()
+                .get(LoggerEventAdapterConstants.ADAPTER_ENABLE_LINE_BREAK));
+        String newLine = (enableLineBreak) ? "\n" : "";
         if (message instanceof Object[]) {
-            log.info("Unique ID: " + uniqueIdentification + ",\n Event: " + Arrays.deepToString((Object[]) message));
+            log.info("Unique ID: " + uniqueIdentification + "," + newLine + " Event: " +
+                    Arrays.deepToString((Object[]) message));
         } else {
-            log.info("Unique ID: " + uniqueIdentification + ",\n Event: " + message);
+            log.info("Unique ID: " + uniqueIdentification + "," + newLine + " Event: " + message);
         }
     }
 

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.logger/src/main/java/org/wso2/carbon/event/output/adapter/logger/LoggerEventAdapterFactory.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.logger/src/main/java/org/wso2/carbon/event/output/adapter/logger/LoggerEventAdapterFactory.java
@@ -46,7 +46,19 @@ public class LoggerEventAdapterFactory extends OutputEventAdapterFactory {
 
     @Override
     public List<Property> getStaticPropertyList() {
-        return null;
+
+        List<Property> staticPropertyList = new ArrayList<Property>();
+
+        // line break property
+        Property enableLineBreak = new Property(LoggerEventAdapterConstants.ADAPTER_ENABLE_LINE_BREAK);
+        enableLineBreak.setDisplayName(resourceBundle.getString(LoggerEventAdapterConstants.ADAPTER_ENABLE_LINE_BREAK));
+        enableLineBreak.setOptions(new String[]{"true", "false"});
+        enableLineBreak.setDefaultValue("true");
+        enableLineBreak.setHint(resourceBundle.getString(LoggerEventAdapterConstants.ADAPTER_ENABLE_LINE_BREAK_HINT));
+
+        staticPropertyList.add(enableLineBreak);
+
+        return staticPropertyList;
     }
 
     @Override

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.logger/src/main/java/org/wso2/carbon/event/output/adapter/logger/internal/util/LoggerEventAdapterConstants.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.logger/src/main/java/org/wso2/carbon/event/output/adapter/logger/internal/util/LoggerEventAdapterConstants.java
@@ -26,5 +26,6 @@ public final class LoggerEventAdapterConstants {
     public static final String ADAPTER_TYPE_LOGGER = "logger";
     public static final String ADAPTER_MESSAGE_UNIQUE_ID = "uniqueId";
     public static final String ADAPTER_MESSAGE_UNIQUE_ID_HINT = "uniqueIdHint";
-
+    public static final String ADAPTER_ENABLE_LINE_BREAK = "enableLineBreak";
+    public static final String ADAPTER_ENABLE_LINE_BREAK_HINT = "enableLineBreakHint";
 }

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.logger/src/main/resources/org/wso2/carbon/event/output/adapter/logger/i18n/Resources.properties
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.logger/src/main/resources/org/wso2/carbon/event/output/adapter/logger/i18n/Resources.properties
@@ -18,4 +18,6 @@
 
 uniqueId=Unique Identifier
 uniqueIdHint=To uniquely identify a log entry
+enableLineBreak=Enable Line Break
+enableLineBreakHint=To enable a line break between Unique Identifier and Event details in a log entry
 

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.logger/src/test/java/org/wso2/carbon/event/output/adapter/logger/LoggerPublisherTestCase.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.logger/src/test/java/org/wso2/carbon/event/output/adapter/logger/LoggerPublisherTestCase.java
@@ -149,7 +149,27 @@ public class LoggerPublisherTestCase {
         eventAdapterConfiguration.setStaticProperties(staticProperties);
         Map<String, String> globalProperties = new HashMap<>();
         adapterFactory.createEventAdapter(eventAdapterConfiguration, globalProperties);
-        Assert.assertEquals(adapterFactory.getStaticPropertyList(),null);
+
+        List<Property> staticProps = adapterFactory.getStaticPropertyList();
+        List<Property> staticPropertyList = new ArrayList<>();
+        Property lineBreakProperty = new Property("enableLineBreak");
+        lineBreakProperty.setRequired(false);
+        lineBreakProperty.setSecured(false);
+        lineBreakProperty.setEncrypted(false);
+        lineBreakProperty.setDisplayName("Enable Line Break");
+        lineBreakProperty.setDefaultValue("true");
+        lineBreakProperty.setOptions(new String[]{"true", "false"});
+        lineBreakProperty.setHint("To enable a line break between Unique Identifier and Event details in a log entry");
+        staticPropertyList.add(lineBreakProperty);
+        Assert.assertEquals(staticPropertyList.size(), staticProps.size());
+        i = 0;
+        for (Property prop : staticPropertyList) {
+            Assert.assertEquals(prop.getPropertyName(), staticProps.get(i).getPropertyName());
+            Assert.assertEquals(prop.getDefaultValue(), staticProps.get(i).getDefaultValue());
+            Assert.assertEquals(prop.getDisplayName(), staticProps.get(i).getDisplayName());
+            Assert.assertEquals(prop.getHint(), staticProps.get(i).getHint());
+            i++;
+        }
         Assert.assertEquals(adapterFactory.getUsageTips(),null);
     }
 }


### PR DESCRIPTION
## Purpose
Introduce a new static property called "enableLineBreak" to the LoggerEventAdapter which will allow to toggle a line break between Unique Identifier and Event details in a log entry

## Approach
The "enableLineBreak" property will have a default value of "true". 
- If the enableLineBreak value is true -> a line break will be added between Unique Identifier and Event details in a log entry
- If the enableLineBreak value is false -> a line break will not be added between Unique Identifier and Event details in a log entry

## Instructions
When adding a new logger output event adapter through the management console, a new property called "Enable Line Break" is available under "Static Adapter Properties". The available options for this property are "true" and "false". A preferred option can be selected when creating the logger output event adapter.

If "true" is selected - a line break will be added between the Unique Identifier and Event details in a log entry
If "false" is selected - a line break will not be added between the Unique Identifier and Event details in a log entry

The log entries before introducing this property contained a line break between the Unique Identifier and Event details. The default value of the "Enable Line Break" property is "true". Hence, there is no impact to existing logger output event adapters due to the introduction of the "Enable Line Break" property.

To edit the "Enable Line Break" property value of a logger output event adapter, one of the following methods can be used.

**Method 1:**
1. Navigate to Main > Manage > Event > Publishers section in the management console which will display the "Available Event Publishers" page.
2. Locate the logger output event adapter which requires editing and click "Edit" under the "Actions" column.
3. In the editor, look for \<property name="enableLineBreak"\>
   a. If it is available, edit the value. Available options are "true" and "false".
   b. If it is not available, make changes so that the content contains the following.
      \<to eventAdapterType="logger">
          \<property name="enableLineBreak">{value}</property\>
      </to\>
      (Replace {value} with either "true" or "false")
4. Click "Update" to save the changes.

**Method 2:**
1. Navigate to the <API-M_HOME>/repository/deployment/server/eventpublishers directory and open the logger output event adapter xml file which requires editing.
2. In the file, look for \<property name="enableLineBreak"\>
   a. If it is available, edit the value. Available options are "true" and "false".
   b. If it is not available, make changes so that the content contains the following.
      \<to eventAdapterType="logger">
          \<property name="enableLineBreak">{value}</property\>
      </to\>
      (Replace {value} with either "true" or "false")
3. Save the file.

## Related Issue
https://github.com/wso2/product-apim/issues/11385

## Related PRs
[WUM][5.2.26] https://github.com/wso2-support/carbon-analytics-common/pull/253
[U2][5.2.26] https://github.com/wso2-support/carbon-analytics-common/pull/255