### PR TITLE
Add Azure output event adapter configs

### DIFF
--- a/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/templates/repository/conf/output-event-adapters.xml.j2
+++ b/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/templates/repository/conf/output-event-adapters.xml.j2
@@ -161,4 +161,36 @@
     {% endif %}
     {% endfor %}
 
+    {% if output_adapter.azure is defined %}
+    <adapterConfig type="azure">
+        {% if output_adapter.azure.properties is defined %}
+        <!-- Custom Properties -->
+        {% for property_name,property_value in output_adapter.azure.properties.items() %}
+        <property key="{{property_name}}">{{property_value}}</property>
+        {% endfor %}
+        {% endif %}
+        <!-- Thread Pool Related Properties -->
+        {% if output_adapter.azure.minThread is defined %}
+        <property key="minThread">{{output_adapter.azure.minThread}}</property>
+        {% else %}
+        <property key="minThread">8</property>
+        {% endif %}
+        {% if output_adapter.azure.maxThread is defined %}
+        <property key="maxThread">{{output_adapter.azure.maxThread}}</property>
+        {% else %}
+        <property key="maxThread">100</property>
+        {% endif %}
+        {% if output_adapter.azure.keepAliveTimeInMillis is defined %}
+        <property key="keepAliveTimeInMillis">{{output_adapter.azure.keepAliveTimeInMillis}}</property>
+        {% else %}
+        <property key="keepAliveTimeInMillis">20000</property>
+        {% endif %}
+        {% if output_adapter.azure.jobQueueSize is defined %}
+        <property key="jobQueueSize">{{output_adapter.azure.jobQueueSize}}</property>
+        {% else %}
+        <property key="jobQueueSize">10000</property>
+        {% endif %}
+    </adapterConfig>
+    {% endif %}
+
 </outputEventAdaptersConfig>

--- a/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/templates/repository/conf/output-event-adapters.xml.j2
+++ b/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/templates/repository/conf/output-event-adapters.xml.j2
@@ -157,40 +157,29 @@
         {% for key,value in adapter.properties.items() %}
         <property key="{{key}}">{{value}}</property>
         {% endfor %}
-    </adapterConfig>
-    {% endif %}
-    {% endfor %}
-
-    {% if output_adapter.azure is defined %}
-    <adapterConfig type="azure">
-        {% if output_adapter.azure.properties is defined %}
-        <!-- Custom Properties -->
-        {% for property_name,property_value in output_adapter.azure.properties.items() %}
-        <property key="{{property_name}}">{{property_value}}</property>
-        {% endfor %}
-        {% endif %}
         <!-- Thread Pool Related Properties -->
-        {% if output_adapter.azure.minThread is defined %}
-        <property key="minThread">{{output_adapter.azure.minThread}}</property>
+        {% if adapter.minThread is defined %}
+        <property key="minThread">{{adapter.minThread}}</property>
         {% else %}
         <property key="minThread">8</property>
         {% endif %}
-        {% if output_adapter.azure.maxThread is defined %}
-        <property key="maxThread">{{output_adapter.azure.maxThread}}</property>
+        {% if adapter.maxThread is defined %}
+        <property key="maxThread">{{adapter.maxThread}}</property>
         {% else %}
         <property key="maxThread">100</property>
         {% endif %}
-        {% if output_adapter.azure.keepAliveTimeInMillis is defined %}
-        <property key="keepAliveTimeInMillis">{{output_adapter.azure.keepAliveTimeInMillis}}</property>
+        {% if adapter.keepAliveTimeInMillis is defined %}
+        <property key="keepAliveTimeInMillis">{{adapter.keepAliveTimeInMillis}}</property>
         {% else %}
         <property key="keepAliveTimeInMillis">20000</property>
         {% endif %}
-        {% if output_adapter.azure.jobQueueSize is defined %}
-        <property key="jobQueueSize">{{output_adapter.azure.jobQueueSize}}</property>
+        {% if adapter.jobQueueSize is defined %}
+        <property key="jobQueueSize">{{adapter.jobQueueSize}}</property>
         {% else %}
         <property key="jobQueueSize">10000</property>
         {% endif %}
     </adapterConfig>
     {% endif %}
+    {% endfor %}
 
 </outputEventAdaptersConfig>


### PR DESCRIPTION
## Purpose
 Need to add azure output event adapter configs to output-event-adapters.xml.j2 file, in order to make them configurable directly from the deployment.toml file.

