### PR TITLE
Upgrade from log4j1 to log4j2

### DIFF
--- a/components/authentication/org.wso2.carbon.analytics.idp.client/pom.xml
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/pom.xml
@@ -72,8 +72,13 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/util/ExternalIdPClientUtil.java
+++ b/components/authentication/org.wso2.carbon.analytics.idp.client/src/main/java/org/wso2/carbon/analytics/idp/client/external/util/ExternalIdPClientUtil.java
@@ -18,7 +18,8 @@
 package org.wso2.carbon.analytics.idp.client.external.util;
 
 import feign.codec.EncodeException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
@@ -48,7 +49,7 @@ import java.util.stream.Collectors;
  */
 public class ExternalIdPClientUtil {
 
-    private static final Logger log = Logger.getLogger(ExternalIdPClientUtil.class);
+    private static final Logger log = LogManager.getLogger(ExternalIdPClientUtil.class);
 
     private static final IdPClientConfiguration idPClientConfiguration = getIdPClientConfiguration();
 

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/pom.xml
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/pom.xml
@@ -64,14 +64,32 @@
         <dependency>
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.databridge.commons</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.databridge.commons.thrift</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.databridge.commons.binary</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.analytics-common</groupId>
@@ -121,16 +139,28 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.log4j.wso2</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.config</groupId>
             <artifactId>org.wso2.carbon.config</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.secvault</groupId>
             <artifactId>org.wso2.carbon.secvault</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/AgentHolder.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/AgentHolder.java
@@ -17,7 +17,8 @@
 */
 package org.wso2.carbon.databridge.agent;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.config.ConfigProviderFactory;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
@@ -50,7 +51,7 @@ import static org.wso2.carbon.databridge.agent.util.DataEndpointConstants.TRANSP
 
 public class AgentHolder {
 
-    private static final Logger log = Logger.getLogger(AgentHolder.class);
+    private static final Logger log = LogManager.getLogger(AgentHolder.class);
     private static String configPath;
     private static AgentHolder instance;
     private Map<String, DataEndpointAgent> dataEndpointAgents;

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
@@ -17,7 +17,8 @@
 */
 package org.wso2.carbon.databridge.agent;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.agent.conf.DataEndpointConfiguration;
 import org.wso2.carbon.databridge.agent.endpoint.DataEndpoint;
 import org.wso2.carbon.databridge.agent.endpoint.DataEndpointGroup;
@@ -39,7 +40,7 @@ import java.util.Map;
  */
 public class DataPublisher {
 
-    private static final Logger log = Logger.getLogger(DataPublisher.class);
+    private static final Logger log = LogManager.getLogger(DataPublisher.class);
 
     /**
      * List of group of endpoints where events needs to dispatched when

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
@@ -19,7 +19,8 @@
 package org.wso2.carbon.databridge.agent.endpoint;
 
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.agent.conf.DataEndpointConfiguration;
 import org.wso2.carbon.databridge.agent.exception.DataEndpointAuthenticationException;
 import org.wso2.carbon.databridge.agent.exception.DataEndpointException;
@@ -45,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 
 public abstract class DataEndpoint {
 
-    private static final Logger log = Logger.getLogger(DataEndpoint.class);
+    private static final Logger log = LogManager.getLogger(DataEndpoint.class);
 
     private DataEndpointConnectionWorker connectionWorker;
 

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointConnectionWorker.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointConnectionWorker.java
@@ -17,7 +17,8 @@
 */
 package org.wso2.carbon.databridge.agent.endpoint;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.agent.conf.DataEndpointConfiguration;
 import org.wso2.carbon.databridge.agent.exception.DataEndpointAuthenticationException;
 import org.wso2.carbon.databridge.agent.exception.DataEndpointException;
@@ -28,7 +29,7 @@ import org.wso2.carbon.databridge.agent.exception.DataEndpointException;
 
 public class DataEndpointConnectionWorker implements Runnable {
 
-    private static final Logger log = Logger.getLogger(DataEndpointConnectionWorker.class);
+    private static final Logger log = LogManager.getLogger(DataEndpointConnectionWorker.class);
 
     private DataEndpointConfiguration dataEndpointConfiguration;
 

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -17,14 +17,14 @@
 */
 package org.wso2.carbon.databridge.agent.endpoint;
 
-
 import com.lmax.disruptor.BlockingWaitStrategy;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.InsufficientCapacityException;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.agent.DataEndpointAgent;
 import org.wso2.carbon.databridge.agent.exception.DataEndpointConfigurationException;
 import org.wso2.carbon.databridge.agent.exception.EventQueueFullException;
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * provided the load balancing, or failover configuration.
  */
 public class DataEndpointGroup implements DataEndpointFailureCallback {
-    private static final Logger log = Logger.getLogger(DataEndpointGroup.class);
+    private static final Logger log = LogManager.getLogger(DataEndpointGroup.class);
 
     private List<DataEndpoint> dataEndpoints;
 

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/binary/BinaryClientPoolFactory.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/binary/BinaryClientPoolFactory.java
@@ -17,7 +17,8 @@
 */
 package org.wso2.carbon.databridge.agent.endpoint.binary;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.agent.AgentHolder;
 import org.wso2.carbon.databridge.agent.client.AbstractClientPoolFactory;
 import org.wso2.carbon.databridge.agent.conf.DataEndpointConfiguration;
@@ -32,7 +33,7 @@ import java.net.Socket;
  * This class implements AbstractClientPoolFactory to handle the Binary transport related connections.
  */
 public class BinaryClientPoolFactory extends AbstractClientPoolFactory {
-    private static final Logger log = Logger.getLogger(BinaryClientPoolFactory.class);
+    private static final Logger log = LogManager.getLogger(BinaryClientPoolFactory.class);
 
     @Override
     public Object createClient(String protocol, String hostName, int port) throws DataEndpointException,

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/binary/BinarySecureClientPoolFactory.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/binary/BinarySecureClientPoolFactory.java
@@ -17,7 +17,8 @@
 */
 package org.wso2.carbon.databridge.agent.endpoint.binary;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.agent.AgentHolder;
 import org.wso2.carbon.databridge.agent.client.AbstractSecureClientPoolFactory;
 import org.wso2.carbon.databridge.agent.conf.DataEndpointConfiguration;
@@ -35,7 +36,7 @@ import javax.net.ssl.SSLSocketFactory;
  * This is a Binary Transport secure implementation for AbstractSecureClientPoolFactory to be used by BinaryEndpoint.
  */
 public class BinarySecureClientPoolFactory extends AbstractSecureClientPoolFactory {
-    private static final Logger log = Logger.getLogger(BinarySecureClientPoolFactory.class);
+    private static final Logger log = LogManager.getLogger(BinarySecureClientPoolFactory.class);
 
     public BinarySecureClientPoolFactory(String trustStore, String trustStorePassword) {
         super(trustStore, trustStorePassword);

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/thrift/ThriftEventConverter.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/thrift/ThriftEventConverter.java
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.databridge.agent.endpoint.thrift;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.commons.Event;
 import org.wso2.carbon.databridge.commons.thrift.data.ThriftEventBundle;
 import org.wso2.carbon.databridge.commons.utils.EventDefinitionConverterUtils;
@@ -33,7 +34,7 @@ import java.util.Map;
  */
 
 public final class ThriftEventConverter {
-    private static final Logger log = Logger.getLogger(ThriftEventConverter.class);
+    private static final Logger log = LogManager.getLogger(ThriftEventConverter.class);
 
     private ThriftEventConverter() {
     }

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/internal/DataAgentDS.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/internal/DataAgentDS.java
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.databridge.agent.internal;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -35,7 +36,7 @@ import org.wso2.carbon.config.provider.ConfigProvider;
         immediate = true
 )
 public class DataAgentDS {
-    private static final Logger log = Logger.getLogger(DataAgentDS.class);
+    private static final Logger log = LogManager.getLogger(DataAgentDS.class);
 
     /**
      * This will be called when its references are satisfied. Data Agent component is initialized here

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/resources/log4j2.properties
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/resources/log4j2.properties
@@ -1,0 +1,40 @@
+#
+# /*
+#  * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#  *
+#  * WSO2 Inc. licenses this file to you under the Apache License,
+#  * Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *     http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing,
+#  * software distributed under the License is distributed on an
+#  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  * KIND, either express or implied. See the License for the
+#  * specific language governing permissions and limitations
+#  * under the License.
+#  */
+#
+
+
+# For the general syntax of property based configuration files see the
+# documenation of org.apache.log4j.PropertyConfigurator.
+
+# The root category uses the appender called A1. Since no priority is
+# specified, the root category assumes the default priority for root
+# which is DEBUG in log4j. The root category is the only category that
+# has a default priority. All other categories need not be assigned a
+# priority in which case they inherit their priority from the
+# hierarchy.
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%t] %-5p %c %x - %m%n
+
+# Root logger referring to console appender
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = consoleLogger

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/resources/log4j2.properties
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/resources/log4j2.properties
@@ -1,0 +1,40 @@
+#
+# /*
+#  * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#  *
+#  * WSO2 Inc. licenses this file to you under the Apache License,
+#  * Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *     http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing,
+#  * software distributed under the License is distributed on an
+#  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  * KIND, either express or implied. See the License for the
+#  * specific language governing permissions and limitations
+#  * under the License.
+#  */
+#
+
+
+# For the general syntax of property based configuration files see the
+# documenation of org.apache.log4j.PropertyConfigurator.
+
+# The root category uses the appender called A1. Since no priority is
+# specified, the root category assumes the default priority for root
+# which is DEBUG in log4j. The root category is the only category that
+# has a default priority. All other categories need not be assigned a
+# priority in which case they inherit their priority from the
+# hierarchy.
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%t] %-5p %c %x - %m%n
+
+# Root logger referring to console appender
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = consoleLogger

--- a/components/data-bridge/org.wso2.carbon.databridge.commons.binary/pom.xml
+++ b/components/data-bridge/org.wso2.carbon.databridge.commons.binary/pom.xml
@@ -46,8 +46,8 @@
             <artifactId>testng</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.log4j.wso2</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
 
     </dependencies>

--- a/components/data-bridge/org.wso2.carbon.databridge.commons.binary/src/test/java/org/wso2/carbon/databridge/commons/binary/test/BinaryMessageConvertUtilTest.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.commons.binary/src/test/java/org/wso2/carbon/databridge/commons/binary/test/BinaryMessageConvertUtilTest.java
@@ -17,7 +17,8 @@
 */
 package org.wso2.carbon.databridge.commons.binary.test;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -37,7 +38,7 @@ import java.nio.charset.StandardCharsets;
  * Binary Message Convert Util Testcase.
  */
 public class BinaryMessageConvertUtilTest {
-    private static final Logger log = Logger.getLogger(BinaryMessageConvertUtilTest.class);
+    private static final Logger log = LogManager.getLogger(BinaryMessageConvertUtilTest.class);
 
     @Test
     public void testEventBufferSize() {

--- a/components/data-bridge/org.wso2.carbon.databridge.commons.thrift/pom.xml
+++ b/components/data-bridge/org.wso2.carbon.databridge.commons.thrift/pom.xml
@@ -54,8 +54,8 @@
             <artifactId>libthrift</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.log4j.wso2</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/components/data-bridge/org.wso2.carbon.databridge.commons/pom.xml
+++ b/components/data-bridge/org.wso2.carbon.databridge.commons/pom.xml
@@ -65,8 +65,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.log4j.wso2</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
 
     </dependencies>

--- a/components/data-bridge/org.wso2.carbon.databridge.commons/src/main/java/org/wso2/carbon/databridge/commons/utils/EventConverterUtils.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.commons/src/main/java/org/wso2/carbon/databridge/commons/utils/EventConverterUtils.java
@@ -21,8 +21,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.wso2.carbon.databridge.commons.Attribute;
@@ -42,7 +42,7 @@ import java.util.Set;
  */
 public class EventConverterUtils {
 
-    private static Logger log = LogManager.getLogger(EventConverterUtils.class);
+    private static final Logger log = LogManager.getLogger(EventConverterUtils.class);
 
     private static Gson gson = new Gson();
     /*

--- a/components/data-bridge/org.wso2.carbon.databridge.commons/src/main/resources/log4j2.properties
+++ b/components/data-bridge/org.wso2.carbon.databridge.commons/src/main/resources/log4j2.properties
@@ -1,0 +1,40 @@
+#
+# /*
+#  * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#  *
+#  * WSO2 Inc. licenses this file to you under the Apache License,
+#  * Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *     http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing,
+#  * software distributed under the License is distributed on an
+#  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  * KIND, either express or implied. See the License for the
+#  * specific language governing permissions and limitations
+#  * under the License.
+#  */
+#
+
+
+# For the general syntax of property based configuration files see the
+# documenation of org.apache.log4j.PropertyConfigurator.
+
+# The root category uses the appender called A1. Since no priority is
+# specified, the root category assumes the default priority for root
+# which is DEBUG in log4j. The root category is the only category that
+# has a default priority. All other categories need not be assigned a
+# priority in which case they inherit their priority from the
+# hierarchy.
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%t] %-5p %c %x - %m%n
+
+# Root logger referring to console appender
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = consoleLogger

--- a/components/data-bridge/org.wso2.carbon.databridge.core/pom.xml
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/pom.xml
@@ -76,8 +76,8 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.log4j.wso2</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.config</groupId>

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/DataBridge.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/DataBridge.java
@@ -20,7 +20,8 @@ package org.wso2.carbon.databridge.core;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.config.ConfigProviderFactory;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
@@ -70,7 +71,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class DataBridge implements DataBridgeSubscriberService, DataBridgeReceiverService {
 
-    private static final Logger log = Logger.getLogger(DataBridge.class);
+    private static final Logger log = LogManager.getLogger(DataBridge.class);
     private StreamDefinitionStore streamDefinitionStore;
     private EventDispatcher eventDispatcher;
     private Authenticator authenticator;

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/DataBridgeStreamStore.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/DataBridgeStreamStore.java
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.databridge.core;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.commons.StreamDefinition;
 import org.wso2.carbon.databridge.core.definitionstore.InMemoryStreamDefinitionStore;
 import org.wso2.carbon.databridge.core.exception.StreamDefinitionStoreException;
@@ -28,7 +29,7 @@ import org.wso2.carbon.databridge.core.exception.StreamDefinitionStoreException;
  */
 public class DataBridgeStreamStore {
 
-    private static final Logger log = Logger.getLogger(DataBridgeStreamStore.class);
+    private static final Logger log = LogManager.getLogger(DataBridgeStreamStore.class);
 
     public void addStreamDefinition(StreamDefinition streamDefinition) {
 

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/definitionstore/AbstractStreamDefinitionStore.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/definitionstore/AbstractStreamDefinitionStore.java
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.databridge.core.definitionstore;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.commons.StreamDefinition;
 import org.wso2.carbon.databridge.commons.exception.DifferentStreamDefinitionAlreadyDefinedException;
 import org.wso2.carbon.databridge.commons.utils.EventDefinitionConverterUtils;
@@ -34,7 +35,7 @@ import java.util.List;
  */
 public abstract class AbstractStreamDefinitionStore implements StreamDefinitionStore {
 
-    private static final Logger log = Logger.getLogger(AbstractStreamDefinitionStore.class);
+    private static final Logger log = LogManager.getLogger(AbstractStreamDefinitionStore.class);
     private List<StreamAddRemoveListener> streamAddRemoveListenerList = new ArrayList<StreamAddRemoveListener>();
 
     public StreamDefinition getStreamDefinition(String name,

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/DataBridgeDS.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/DataBridgeDS.java
@@ -16,7 +16,8 @@
 
 package org.wso2.carbon.databridge.core.internal;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
@@ -50,7 +51,7 @@ import java.util.LinkedHashMap;
         immediate = true
 )
 public class DataBridgeDS {
-    private static final Logger log = Logger.getLogger(DataBridgeDS.class);
+    private static final Logger log = LogManager.getLogger(DataBridgeDS.class);
     private ServiceRegistration receiverServiceRegistration;
     private ServiceRegistration subscriberServiceRegistration;
     private ServiceRegistration dataBridgeEventStreamServiceRegistration;

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/EventDispatcher.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/EventDispatcher.java
@@ -18,8 +18,8 @@
 
 package org.wso2.carbon.databridge.core.internal;
 
-
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.commons.Attribute;
 import org.wso2.carbon.databridge.commons.StreamDefinition;
 import org.wso2.carbon.databridge.commons.exception.DifferentStreamDefinitionAlreadyDefinedException;
@@ -57,7 +57,7 @@ public class EventDispatcher {
     private StreamTypeHolder streamTypeHolder;
     private EventQueue eventQueue;
 
-    private static final Logger log = Logger.getLogger(EventDispatcher.class);
+    private static final Logger log = LogManager.getLogger(EventDispatcher.class);
 
 
     public EventDispatcher(AbstractStreamDefinitionStore streamDefinitionStore,

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/authentication/Authenticator.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/authentication/Authenticator.java
@@ -19,7 +19,8 @@
 
 package org.wso2.carbon.databridge.core.internal.authentication;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.commons.Credentials;
 import org.wso2.carbon.databridge.commons.exception.AuthenticationException;
 import org.wso2.carbon.databridge.core.conf.DataBridgeConfiguration;
@@ -34,7 +35,7 @@ import java.util.UUID;
  */
 public final class Authenticator {
 
-    private static final Logger log = Logger.getLogger(Authenticator.class);
+    private static final Logger log = LogManager.getLogger(Authenticator.class);
     private SessionCache sessionCache;
     private AuthenticationHandler authenticationHandler;
 

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/queue/EventBlockingQueue.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/queue/EventBlockingQueue.java
@@ -17,7 +17,8 @@
 */
 package org.wso2.carbon.databridge.core.internal.queue;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.core.utils.DataBridgeUtils;
 import org.wso2.carbon.databridge.core.utils.EventComposite;
 
@@ -30,7 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * the queue doesn't grow beyond the determined size.
  */
 public class EventBlockingQueue extends ArrayBlockingQueue<EventComposite> {
-    private static final Logger log = Logger.getLogger(EventBlockingQueue.class);
+    private static final Logger log = LogManager.getLogger(EventBlockingQueue.class);
     private final Object lock = new Object();
     private AtomicInteger currentSize;
     private int currentEventCompositeSize;

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/queue/EventQueue.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/queue/EventQueue.java
@@ -17,7 +17,8 @@
 */
 package org.wso2.carbon.databridge.core.internal.queue;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.commons.utils.DataBridgeThreadFactory;
 import org.wso2.carbon.databridge.core.AgentCallback;
 import org.wso2.carbon.databridge.core.RawDataAgentCallback;
@@ -34,7 +35,7 @@ import java.util.concurrent.Executors;
  */
 public class EventQueue {
 
-    private static final Logger log = Logger.getLogger(EventQueue.class);
+    private static final Logger log = LogManager.getLogger(EventQueue.class);
 
     private BlockingQueue<EventComposite> eventQueue;
 

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/queue/QueueWorker.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/queue/QueueWorker.java
@@ -17,7 +17,8 @@
 */
 package org.wso2.carbon.databridge.core.internal.queue;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.commons.Event;
 import org.wso2.carbon.databridge.core.AgentCallback;
 import org.wso2.carbon.databridge.core.RawDataAgentCallback;
@@ -34,7 +35,7 @@ import java.util.concurrent.ThreadPoolExecutor;
  */
 public class QueueWorker implements Runnable {
 
-    private static final Logger log = Logger.getLogger(QueueWorker.class);
+    private static final Logger log = LogManager.getLogger(QueueWorker.class);
     private BlockingQueue<EventComposite> eventQueue;
     private List<AgentCallback> subscribers;
     private List<RawDataAgentCallback> rawDataSubscribers;

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/utils/DataBridgeUtils.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/utils/DataBridgeUtils.java
@@ -19,7 +19,8 @@
 
 package org.wso2.carbon.databridge.core.utils;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.commons.Attribute;
 import org.wso2.carbon.databridge.commons.AttributeType;
 import org.wso2.carbon.databridge.commons.Event;
@@ -34,7 +35,7 @@ import java.util.List;
  */
 public class DataBridgeUtils {
 
-    private static final Logger log = Logger.getLogger(DataBridgeUtils.class);
+    private static final Logger log = LogManager.getLogger(DataBridgeUtils.class);
 
     public static boolean equals(Event event1, Event event2, StreamDefinition streamDefinition) {
         if (event1 == event2) {

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/resources/log4j2.properties
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/resources/log4j2.properties
@@ -1,0 +1,40 @@
+#
+# /*
+#  * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#  *
+#  * WSO2 Inc. licenses this file to you under the Apache License,
+#  * Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *     http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing,
+#  * software distributed under the License is distributed on an
+#  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  * KIND, either express or implied. See the License for the
+#  * specific language governing permissions and limitations
+#  * under the License.
+#  */
+#
+
+
+# For the general syntax of property based configuration files see the
+# documenation of org.apache.log4j.PropertyConfigurator.
+
+# The root category uses the appender called A1. Since no priority is
+# specified, the root category assumes the default priority for root
+# which is DEBUG in log4j. The root category is the only category that
+# has a default priority. All other categories need not be assigned a
+# priority in which case they inherit their priority from the
+# hierarchy.
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%t] %-5p %c %x - %m%n
+
+# Root logger referring to console appender
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = consoleLogger

--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/test/resources/log4j2.properties
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/test/resources/log4j2.properties
@@ -1,0 +1,40 @@
+#
+# /*
+#  * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#  *
+#  * WSO2 Inc. licenses this file to you under the Apache License,
+#  * Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *     http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing,
+#  * software distributed under the License is distributed on an
+#  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  * KIND, either express or implied. See the License for the
+#  * specific language governing permissions and limitations
+#  * under the License.
+#  */
+#
+
+
+# For the general syntax of property based configuration files see the
+# documenation of org.apache.log4j.PropertyConfigurator.
+
+# The root category uses the appender called A1. Since no priority is
+# specified, the root category assumes the default priority for root
+# which is DEBUG in log4j. The root category is the only category that
+# has a default priority. All other categories need not be assigned a
+# priority in which case they inherit their priority from the
+# hierarchy.
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%t] %-5p %c %x - %m%n
+
+# Root logger referring to console appender
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = consoleLogger

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/internal/BinaryDataReceiver.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/internal/BinaryDataReceiver.java
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.databridge.receiver.binary.internal;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.commons.ServerEventListener;
 import org.wso2.carbon.databridge.commons.binary.BinaryMessageConstants;
 import org.wso2.carbon.databridge.core.DataBridgeReceiverService;
@@ -60,7 +61,7 @@ import static org.wso2.carbon.databridge.commons.binary.BinaryMessageConverterUt
  * Binary Transport Receiver implementation.
  */
 public class BinaryDataReceiver implements ServerEventListener {
-    private static final Logger log = Logger.getLogger(BinaryDataReceiver.class);
+    private static final Logger log = LogManager.getLogger(BinaryDataReceiver.class);
     private DataBridgeReceiverService dataBridgeReceiverService;
     private BinaryDataReceiverConfiguration binaryDataReceiverConfiguration;
     private ExecutorService sslReceiverExecutorService;

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/internal/BinaryDataReceiverServiceComponent.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.binary/src/main/java/org/wso2/carbon/databridge/receiver/binary/internal/BinaryDataReceiverServiceComponent.java
@@ -17,7 +17,8 @@
  */
 package org.wso2.carbon.databridge.receiver.binary.internal;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -37,7 +38,7 @@ import org.wso2.carbon.kernel.CarbonRuntime;
         immediate = true
 )
 public class BinaryDataReceiverServiceComponent {
-    private static final Logger log = Logger.getLogger(BinaryDataReceiverServiceComponent.class);
+    private static final Logger log = LogManager.getLogger(BinaryDataReceiverServiceComponent.class);
     private DataBridgeReceiverService dataBridgeReceiverService;
     private static CarbonRuntime carbonRuntime;
     private BinaryDataReceiver binaryDataReceiver;

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/ThriftDataReceiver.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/ThriftDataReceiver.java
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.databridge.receiver.thrift;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.server.TServer;
 import org.apache.thrift.server.TThreadPoolServer;
 import org.apache.thrift.transport.TSSLTransportFactory;
@@ -50,7 +51,7 @@ import javax.net.ssl.SSLServerSocket;
  * Carbon based implementation of the agent server.
  */
 public class ThriftDataReceiver {
-    private static final Logger log = Logger.getLogger(ThriftDataReceiver.class);
+    private static final Logger log = LogManager.getLogger(ThriftDataReceiver.class);
     private DataBridgeReceiverService dataBridgeReceiverService;
     private ThriftDataReceiverConfiguration thriftDataReceiverConfiguration;
     private TServer authenticationServer;

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/ThriftDataReceiverDS.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/ThriftDataReceiverDS.java
@@ -17,7 +17,8 @@
 
 package org.wso2.carbon.databridge.receiver.thrift.internal;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -40,7 +41,7 @@ import org.wso2.carbon.kernel.CarbonRuntime;
 )
 
 public class ThriftDataReceiverDS {
-    private static final Logger log = Logger.getLogger(ThriftDataReceiverDS.class);
+    private static final Logger log = LogManager.getLogger(ThriftDataReceiverDS.class);
     private ThriftServerStartupImpl thriftDataReceiver;
 
     /**

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/ThriftServerStartupImpl.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/main/java/org/wso2/carbon/databridge/receiver/thrift/internal/ThriftServerStartupImpl.java
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.databridge.receiver.thrift.internal;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.commons.ServerEventListener;
 import org.wso2.carbon.databridge.commons.thrift.utils.HostAddressFinder;
 import org.wso2.carbon.databridge.core.exception.DataBridgeException;
@@ -30,7 +31,7 @@ import org.wso2.carbon.databridge.receiver.thrift.conf.ThriftDataReceiverConfigu
  */
 public class ThriftServerStartupImpl implements ServerEventListener {
 
-    private static final Logger log = Logger.getLogger(ThriftServerStartupImpl.class);
+    private static final Logger log = LogManager.getLogger(ThriftServerStartupImpl.class);
     private static final String DISABLE_RECEIVER = "disable.receiver";
     private boolean isStarted = false;
 

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/test/java/org/wso2/carbon/databridge/receiver/thrift/test/ThriftDataReceiverTest.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/test/java/org/wso2/carbon/databridge/receiver/thrift/test/ThriftDataReceiverTest.java
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.databridge.receiver.thrift.test;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.databridge.commons.StreamDefinition;
@@ -44,7 +45,7 @@ import java.io.File;
  */
 public class ThriftDataReceiverTest {
 
-    private static Logger log = Logger.getLogger(ThriftDataReceiverTest.class);
+    private static final Logger log = LogManager.getLogger(ThriftDataReceiverTest.class);
 
     private static final String STREAM_NAME = "org.wso2.esb.MediatorStatistics";
     private static final String VERSION = "1.0.0";

--- a/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/test/java/org/wso2/carbon/databridge/receiver/thrift/test/util/ThriftServerUtil.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.receiver.thrift/src/test/java/org/wso2/carbon/databridge/receiver/thrift/test/util/ThriftServerUtil.java
@@ -18,7 +18,8 @@
 
 package org.wso2.carbon.databridge.receiver.thrift.test.util;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.config.ConfigProviderFactory;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
@@ -41,7 +42,7 @@ import java.util.LinkedHashMap;
  */
 public class ThriftServerUtil {
 
-    private static Logger log = Logger.getLogger(ThriftServerUtil.class);
+    private static final Logger log = LogManager.getLogger(ThriftServerUtil.class);
 
     public static final Path TEST_DIR = Paths.get("src", "test", "resources");
 

--- a/features/data-bridge/org.wso2.carbon.databridge.agent.feature/pom.xml
+++ b/features/data-bridge/org.wso2.carbon.databridge.agent.feature/pom.xml
@@ -46,14 +46,6 @@
             <groupId>org.wso2.orbit.com.lmax</groupId>
             <artifactId>disruptor</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/features/data-bridge/org.wso2.carbon.databridge.agent.feature/pom.xml
+++ b/features/data-bridge/org.wso2.carbon.databridge.agent.feature/pom.xml
@@ -47,8 +47,8 @@
             <artifactId>disruptor</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -94,14 +94,6 @@
                                 <bundle>
                                     <symbolicName>disruptor</symbolicName>
                                     <version>${disruptor.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>slf4j.log4j12</symbolicName>
-                                    <version>${slf4j.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>slf4j.api</symbolicName>
-                                    <version>${slf4j.version}</version>
                                 </bundle>
                             </bundles>
                         </configuration>

--- a/features/data-bridge/org.wso2.carbon.databridge.commons.thrift.feature/pom.xml
+++ b/features/data-bridge/org.wso2.carbon.databridge.commons.thrift.feature/pom.xml
@@ -45,8 +45,8 @@
             <artifactId>libthrift</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
     </dependencies>
 

--- a/features/data-bridge/org.wso2.carbon.databridge.feature/pom.xml
+++ b/features/data-bridge/org.wso2.carbon.databridge.feature/pom.xml
@@ -95,10 +95,6 @@
             <groupId>org.wso2.orbit.com.lmax</groupId>
             <artifactId>disruptor</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-        </dependency>
 
         <!-- databridge-receiver-binary dependencies -->
         <dependency>

--- a/features/data-bridge/org.wso2.carbon.databridge.feature/pom.xml
+++ b/features/data-bridge/org.wso2.carbon.databridge.feature/pom.xml
@@ -96,8 +96,8 @@
             <artifactId>disruptor</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
 
         <!-- databridge-receiver-binary dependencies -->
@@ -201,14 +201,6 @@
                                 <bundle>
                                     <symbolicName>disruptor</symbolicName>
                                     <version>${disruptor.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>slf4j.log4j12</symbolicName>
-                                    <version>${slf4j.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>slf4j.api</symbolicName>
-                                    <version>${slf4j.version}</version>
                                 </bundle>
 
                                 <!-- databridge-receiver-binary dependencies -->

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -78,6 +78,10 @@
         <Class name="org.wso2.carbon.databridge.agent.endpoint.EventPublisherThreadPoolExecutor"/>
         <Bug pattern="DMI_THREAD_PASSED_WHERE_RUNNABLE_EXPECTED"/>
     </Match>
+    <Match>
+        <Class name="org.wso2.carbon.databridge.core.DataBridge"/>
+        <Bug pattern="NP_NULL_PARAM_DEREF"/>
+    </Match>
 
     <!-- TODO Validate below -->
     <Match>

--- a/pom.xml
+++ b/pom.xml
@@ -719,7 +719,7 @@
 
     <properties>
         <carbon.analytics.common.version>6.1.56-SNAPSHOT</carbon.analytics.common.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <org.jacoco.version>0.7.9</org.jacoco.version>
         <commons.io.version>2.4.0.wso2v1</commons.io.version>
         <commons.pool.version>1.5.6.wso2v1</commons.pool.version>
@@ -730,7 +730,7 @@
         <wso2.slf4j.version>1.5.10.wso2v1</wso2.slf4j.version>
         <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>
 
-        <pax.logging.log4j2.version>1.11.12</pax.logging.log4j2.version>
+        <pax.logging.log4j2.version>1.11.13</pax.logging.log4j2.version>
         <apache.felix.gogo.command.version>0.10.0.v201209301215</apache.felix.gogo.command.version>
         <apache.felix.gogo.runtime.version>0.10.0.v201209301036</apache.felix.gogo.runtime.version>
         <apache.felix.gogo.shell.version>0.10.0.v201212101605</apache.felix.gogo.shell.version>
@@ -771,7 +771,7 @@
 
         <osgi.framework.import.version.range>[1.8.0, 2.0.0)</osgi.framework.import.version.range>
         <osgi.service.tracker.import.version.range>[1.5.1, 2.0.0)</osgi.service.tracker.import.version.range>
-        <carbon.kernel.version>5.2.14-SNAPSHOT</carbon.kernel.version>
+        <carbon.kernel.version>5.2.15</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[5.2.6, 6.0.0)</carbon.kernel.package.import.version.range>
         <slf4j.version>1.7.12</slf4j.version>
         <slf4j.version.range>[1.7,2)</slf4j.version.range>
@@ -780,7 +780,7 @@
         <guava.bundle.version>23.0.0</guava.bundle.version>
         <gson.version>2.8.5</gson.version>
         <gson.version.range>[2.0.0, 3.0.0)</gson.version.range>
-        <pax.logging.api.version>1.11.12</pax.logging.api.version>
+        <pax.logging.api.version>1.11.13</pax.logging.api.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>
 
         <project.scm.id>my-scm-server</project.scm.id>

--- a/pom.xml
+++ b/pom.xml
@@ -375,9 +375,9 @@
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>${slf4j.version}</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>
@@ -415,9 +415,9 @@
                 <version>1.0.0</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.log4j.wso2</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.17.wso2v1</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
 
             <dependency>
@@ -719,6 +719,7 @@
 
     <properties>
         <carbon.analytics.common.version>6.1.56-SNAPSHOT</carbon.analytics.common.version>
+        <log4j.version>2.17.0</log4j.version>
         <org.jacoco.version>0.7.9</org.jacoco.version>
         <commons.io.version>2.4.0.wso2v1</commons.io.version>
         <commons.pool.version>1.5.6.wso2v1</commons.pool.version>
@@ -729,7 +730,7 @@
         <wso2.slf4j.version>1.5.10.wso2v1</wso2.slf4j.version>
         <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>
 
-        <pax.logging.log4j2.version>1.10.1</pax.logging.log4j2.version>
+        <pax.logging.log4j2.version>1.11.12</pax.logging.log4j2.version>
         <apache.felix.gogo.command.version>0.10.0.v201209301215</apache.felix.gogo.command.version>
         <apache.felix.gogo.runtime.version>0.10.0.v201209301036</apache.felix.gogo.runtime.version>
         <apache.felix.gogo.shell.version>0.10.0.v201212101605</apache.felix.gogo.shell.version>
@@ -770,7 +771,7 @@
 
         <osgi.framework.import.version.range>[1.8.0, 2.0.0)</osgi.framework.import.version.range>
         <osgi.service.tracker.import.version.range>[1.5.1, 2.0.0)</osgi.service.tracker.import.version.range>
-        <carbon.kernel.version>5.2.13</carbon.kernel.version>
+        <carbon.kernel.version>5.2.14-SNAPSHOT</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[5.2.6, 6.0.0)</carbon.kernel.package.import.version.range>
         <slf4j.version>1.7.12</slf4j.version>
         <slf4j.version.range>[1.7,2)</slf4j.version.range>
@@ -779,7 +780,7 @@
         <guava.bundle.version>23.0.0</guava.bundle.version>
         <gson.version>2.8.5</gson.version>
         <gson.version.range>[2.0.0, 3.0.0)</gson.version.range>
-        <pax.logging.api.version>1.10.0</pax.logging.api.version>
+        <pax.logging.api.version>1.11.12</pax.logging.api.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>
 
         <project.scm.id>my-scm-server</project.scm.id>


### PR DESCRIPTION
## Purpose
Deprecate log4j1 dependencies

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

