### PR TITLE
Make Failed Event Log Interval time configurable of Datapublisher warning logs

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
@@ -53,7 +53,7 @@ public class DataPublisher {
      */
     private DataEndpointAgent dataEndpointAgent;
     
-    private int failedEventLogInterval;
+    private static int failedEventLogInterval = 10000;
     
     /**
      * The last failed event time kept, use to determine when to log an warning

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
@@ -53,7 +53,7 @@ public class DataPublisher {
      */
     private DataEndpointAgent dataEndpointAgent;
     
-    private static final int FAILED_EVENT_LOG_INTERVAL = 10000;
+    private int failedEventLogInterval;
     
     /**
      * The last failed event time kept, use to determine when to log an warning
@@ -88,6 +88,7 @@ public class DataPublisher {
         dataEndpointAgent = AgentHolder.getInstance().getDefaultDataEndpointAgent();
         processEndpoints(dataEndpointAgent, receiverURLSet, DataPublisherUtil.
                 getDefaultAuthURLSet(receiverURLSet), username, password);
+        failedEventLogInterval = dataEndpointAgent.getAgentConfiguration().getFailedEventLogInterval();
         dataEndpointAgent.addDataPublisher(this);
     }
 
@@ -124,6 +125,7 @@ public class DataPublisher {
             authURLSet = DataPublisherUtil.getDefaultAuthURLSet(receiverURLSet);
         }
         processEndpoints(dataEndpointAgent, receiverURLSet, authURLSet, username, password);
+        failedEventLogInterval = dataEndpointAgent.getAgentConfiguration().getFailedEventLogInterval();
         dataEndpointAgent.addDataPublisher(this);
     }
 
@@ -308,7 +310,7 @@ public class DataPublisher {
     private void onEventQueueFull(DataEndpointGroup endpointGroup, Event event) {
         this.failedEventCount++;
         long currentTime = System.currentTimeMillis();
-        if (currentTime - this.lastFailedEventTime > FAILED_EVENT_LOG_INTERVAL) {
+        if (currentTime - this.lastFailedEventTime > failedEventLogInterval) {
             log.warn("Event queue is full, unable to process the event for endpoint group "
                     + endpointGroup.toString() + ", " + this.failedEventCount + " events dropped so far.");
             this.lastFailedEventTime = currentTime;

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/AgentConfiguration.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/AgentConfiguration.java
@@ -74,6 +74,8 @@ public class AgentConfiguration {
 
     private int loggingControlIntervalInSeconds;
 
+    private int failedEventLogInterval;
+
     @XmlElement(name = "Name")
     public String getDataEndpointName() {
         return dataEndpointName;
@@ -312,6 +314,15 @@ public class AgentConfiguration {
             throw new DataEndpointAgentConfigurationException("Endpoint class name is not set in "
                     + DataEndpointConstants.DATA_AGENT_CONF_FILE_NAME + " for name: " + this.dataEndpointName);
         }
+    }
+
+    @XmlElement(name = "FailedEventLogInterval")
+    public int getFailedEventLogInterval() {
+        return failedEventLogInterval;
+    }
+
+    public void setFailedEventLogInterval(int failedEventLogInterval) {
+        this.failedEventLogInterval = failedEventLogInterval;
     }
 }
 


### PR DESCRIPTION
## Purpose
To make Failed Event Log Interval time configurable to reduce the frequency of Datapublisher warning logs.

## Goals
Fixes: https://github.com/wso2/api-manager/issues/186

## Approach

- Introduced new XML element `FailedEventLogInterval` to data-agent-config.xml.
- The default value will be 10000(milliseconds)
- This can be changed via deployment.toml by adding a property like below

```
[transport.binary.agent]
failed_event_log_interval = <EXPECTED_LOGGING_INTERVAL_IN_MILLISECONDS>
```
