### PR TITLE
Make Failed Event Log Interval time configurable of Datapublisher warning logs

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
@@ -53,7 +53,7 @@ public class DataPublisher {
      */
     private DataEndpointAgent dataEndpointAgent;
 
-    private static final int FAILED_EVENT_LOG_INTERVAL = 10000;
+    private static int failedEventLogInterval = 10000;
 
     /**
      * The last failed event time kept, use to determine when to log an warning
@@ -90,6 +90,7 @@ public class DataPublisher {
         dataEndpointAgent = AgentHolder.getInstance().getDefaultDataEndpointAgent();
         processEndpoints(dataEndpointAgent, receiverURLSet, DataPublisherUtil.
                 getDefaultAuthURLSet(receiverURLSet), username, password);
+        failedEventLogInterval = dataEndpointAgent.getAgentConfiguration().getFailedEventLogInterval();
         dataEndpointAgent.addDataPublisher(this);
     }
 
@@ -129,6 +130,7 @@ public class DataPublisher {
             authURLSet = DataPublisherUtil.getDefaultAuthURLSet(receiverURLSet);
         }
         processEndpoints(dataEndpointAgent, receiverURLSet, authURLSet, username, password);
+        failedEventLogInterval = dataEndpointAgent.getAgentConfiguration().getFailedEventLogInterval();
         dataEndpointAgent.addDataPublisher(this);
     }
 
@@ -300,7 +302,7 @@ public class DataPublisher {
     private void onEventQueueFull(DataEndpointGroup endpointGroup, Event event) {
         this.failedEventCount++;
         long currentTime = System.currentTimeMillis();
-        if (currentTime - this.lastFailedEventTime > FAILED_EVENT_LOG_INTERVAL) {
+        if (currentTime - this.lastFailedEventTime > failedEventLogInterval) {
             log.warn("Event queue is full, unable to process the event for endpoint group "
                     + endpointGroup.toString() + ", " + this.failedEventCount + " events dropped so far.");
             this.lastFailedEventTime = currentTime;

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/AgentConfiguration.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/AgentConfiguration.java
@@ -98,6 +98,9 @@ public class AgentConfiguration {
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
             "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256";
 
+    @Element(description = "Failed event log interval", required = false)
+    private int failedEventLogInterval = 10000;
+
     public String getName() {
         return name;
     }
@@ -274,6 +277,14 @@ public class AgentConfiguration {
         this.ciphers = ciphers;
     }
 
+    public int getFailedEventLogInterval() {
+        return failedEventLogInterval;
+    }
+
+    public void setFailedEventLogInterval(int failedEventLogInterval) {
+        this.failedEventLogInterval = failedEventLogInterval;
+    }
+
     @Override
     public String toString() {
         return ", Name : " + name +
@@ -297,7 +308,8 @@ public class AgentConfiguration {
                 "SecureEvictionTimePeriod" + secureEvictionTimePeriod +
                 "SecureMinIdleTimeInPool" + secureMinIdleTimeInPool +
                 "SSLEnabledProtocols" + sslEnabledProtocols +
-                "Ciphers" + ciphers;
+                "Ciphers" + ciphers +
+                "FailedEventLogInterval" + failedEventLogInterval;
     }
 
     public AgentConfiguration(String name, String dataEndpointClass) {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/DataAgentConfigurationFileResolver.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/DataAgentConfigurationFileResolver.java
@@ -170,6 +170,11 @@ public class DataAgentConfigurationFileResolver {
                     agentConfiguration.setCiphers(agentConfigurationHashMap.get(
                             DataAgentConstants.CIPHERS).toString().trim());
                 }
+
+                if (agentConfigurationHashMap.get(DataAgentConstants.FAILED_EVENT_LOG_INTERVAL) != null) {
+                    agentConfiguration.setFailedEventLogInterval(Integer.parseInt(agentConfigurationHashMap.get(
+                            DataAgentConstants.FAILED_EVENT_LOG_INTERVAL).toString().trim()));
+                }
                 agents.add(agent);
             }
         } else {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/util/DataAgentConstants.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/util/DataAgentConstants.java
@@ -50,6 +50,7 @@ public class DataAgentConstants {
     public static final String SECURE_MIN_IDLE_TIME_IN_POOL = "secureMinIdleTimeInPool";
     public static final String SSL_ENABLED_PROTOCOLS = "sslEnabledProtocols";
     public static final String CIPHERS = "ciphers";
+    public static final String FAILED_EVENT_LOG_INTERVAL = "failedEventLogInterval";
 
 
 


### PR DESCRIPTION
## Purpose
To make Failed Event Log Interval time configurable to reduce the frequency of Datapublisher warning logs.

## Goals
Fixes: https://github.com/wso2/api-manager/issues/186

## Approach

- Introduced new XML element `FailedEventLogInterval` to data-agent-config.xml.
- The default value will be 10000(milliseconds)
- This can be changed via deployment.toml by adding a property like below

```
[transport.binary.agent]
failed_event_log_interval = <EXPECTED_LOGGING_INTERVAL_IN_MILLISECONDS>
```
