### PR TITLE
Add form-url-encoded support for Http event adapter

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/HTTPEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/HTTPEventAdapter.java
@@ -29,6 +29,7 @@ import org.apache.http.conn.params.ConnRoutePNames;
 
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.event.output.adapter.core.EventAdapterUtil;
+import org.wso2.carbon.event.output.adapter.core.MessageType;
 import org.wso2.carbon.event.output.adapter.core.OutputEventAdapter;
 import org.wso2.carbon.event.output.adapter.core.OutputEventAdapterConfiguration;
 import org.wso2.carbon.event.output.adapter.core.exception.OutputEventAdapterException;
@@ -209,10 +210,12 @@ public class HTTPEventAdapter implements OutputEventAdapter {
             }
 
             String messageFormat = eventAdapterConfiguration.getMessageFormat();
-            if (messageFormat.equalsIgnoreCase("json")) {
+            if (messageFormat.equalsIgnoreCase(MessageType.JSON)) {
                 contentType = "application/json";
-            } else if (messageFormat.equalsIgnoreCase("text")) {
+            } else if (messageFormat.equalsIgnoreCase(MessageType.TEXT)) {
                 contentType = "text/plain";
+            } else if (messageFormat.equalsIgnoreCase(MessageType.FORM)) {
+                contentType = "application/x-www-form-urlencoded";
             } else {
                 contentType = "text/xml";
             }

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/HTTPEventAdapterFactory.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/HTTPEventAdapterFactory.java
@@ -40,6 +40,9 @@ public class HTTPEventAdapterFactory extends OutputEventAdapterFactory {
         supportedMessageFormats.add(MessageType.TEXT);
         supportedMessageFormats.add(MessageType.XML);
         supportedMessageFormats.add(MessageType.JSON);
+        if (isFormUrlEncodedEnabled()) {
+            supportedMessageFormats.add(MessageType.FORM);
+        }
         return supportedMessageFormats;
     }
 
@@ -116,5 +119,13 @@ public class HTTPEventAdapterFactory extends OutputEventAdapterFactory {
     public OutputEventAdapter createEventAdapter(OutputEventAdapterConfiguration eventAdapterConfiguration,
                                                  Map<String, String> globalProperties) {
         return new HTTPEventAdapter(eventAdapterConfiguration, globalProperties);
+    }
+
+    private boolean isFormUrlEncodedEnabled() {
+
+        Map<String, String> globalProperties = EventAdapterUtil.
+                getGlobalProperties(HTTPEventAdapterConstants.ADAPTER_TYPE_HTTP);
+        return Boolean
+                .parseBoolean(globalProperties.get(HTTPEventAdapterConstants.ENABLE_FORM_URL_ENCODED));
     }
 }

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/internal/util/HTTPEventAdapterConstants.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/internal/util/HTTPEventAdapterConstants.java
@@ -45,6 +45,7 @@ public class HTTPEventAdapterConstants {
     public static final String ADAPTER_HTTP_CLIENT_METHOD = "http.client.method";
     public static final String CONSTANT_HTTP_POST = "HttpPost";
     public static final String CONSTANT_HTTP_PUT = "HttpPut";
+    public static final String ENABLE_FORM_URL_ENCODED = "enableFormUrlEncoded";
 
     //configurations for the httpConnectionManager
     public static final String DEFAULT_MAX_CONNECTIONS_PER_HOST = "defaultMaxConnectionsPerHost";

--- a/components/event-publisher/org.wso2.carbon.event.output.adapter.core/src/main/java/org/wso2/carbon/event/output/adapter/core/MessageType.java
+++ b/components/event-publisher/org.wso2.carbon.event.output.adapter.core/src/main/java/org/wso2/carbon/event/output/adapter/core/MessageType.java
@@ -24,5 +24,6 @@ public class MessageType {
     public static final String MAP = "map";
     public static final String TEXT = "text";
     public static final String JSON = "json";
+    public static final String FORM = "form";
 
 }

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/config/EventPublisherConstants.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/config/EventPublisherConstants.java
@@ -49,6 +49,7 @@ public final class EventPublisherConstants {
     public static final String EF_MAP_MAPPING_TYPE = "map";
     public static final String EF_XML_MAPPING_TYPE = "xml";
     public static final String EF_JSON_MAPPING_TYPE = "json";
+    public static final String EF_FORM_MAPPING_TYPE = "form";
     public static final String EF_ELE_MAPPING_INLINE = "inline";
     public static final String EF_ELE_MAPPING_REGISTRY = "registry";
     public static final String EF_ELE_CACHE_TIMEOUT_DURATION = "cacheTimeoutDuration";
@@ -101,6 +102,7 @@ public final class EventPublisherConstants {
     public static final String TEMPLATE_EVENT_ATTRIBUTE_PREFIX = "{{";
     public static final String TEMPLATE_EVENT_ATTRIBUTE_POSTFIX = "}}";
     public static final String EVENT_ATTRIBUTE_VALUE_SEPARATOR = ":";
+    public static final String EVENT_FORM_ATTRIBUTE_VALUE_SEPARATOR = "=";
     public static final String EVENT_ATTRIBUTE_SEPARATOR = ",";
     public static final String DEFAULT_STREAM_VERSION = "1.0.0";
 

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/config/mapping/FormOutputMapping.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/config/mapping/FormOutputMapping.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.event.publisher.core.config.mapping;
+
+import org.wso2.carbon.event.publisher.core.config.EventPublisherConstants;
+import org.wso2.carbon.event.publisher.core.config.OutputMapping;
+
+public class FormOutputMapping extends OutputMapping {
+
+    private String mappingText;
+    private boolean registryResource;
+    private long cacheTimeoutDuration;
+
+    public String getMappingText() {
+
+        return mappingText;
+    }
+
+    public void setMappingText(String mappingText) {
+
+        this.mappingText = mappingText;
+    }
+
+    @Override
+    public String getMappingType() {
+
+        return EventPublisherConstants.EF_FORM_MAPPING_TYPE;
+    }
+
+    public boolean isRegistryResource() {
+
+        return registryResource;
+    }
+
+    public void setRegistryResource(boolean registryResource) {
+
+        this.registryResource = registryResource;
+    }
+
+    public long getCacheTimeoutDuration() {
+
+        return cacheTimeoutDuration;
+    }
+
+    public void setCacheTimeoutDuration(long cacheTimeoutDuration) {
+
+        this.cacheTimeoutDuration = cacheTimeoutDuration;
+    }
+}

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/ds/EventPublisherServiceValueHolder.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/ds/EventPublisherServiceValueHolder.java
@@ -21,6 +21,7 @@ import org.wso2.carbon.event.publisher.core.EventPublisherService;
 import org.wso2.carbon.event.publisher.core.config.OutputMapperFactory;
 import org.wso2.carbon.event.publisher.core.internal.CarbonEventPublisherManagementService;
 import org.wso2.carbon.event.publisher.core.internal.CarbonEventPublisherService;
+import org.wso2.carbon.event.publisher.core.internal.type.form.FormOutputMapperFactory;
 import org.wso2.carbon.event.publisher.core.internal.type.json.JSONOutputMapperFactory;
 import org.wso2.carbon.event.publisher.core.internal.type.map.MapOutputMapperFactory;
 import org.wso2.carbon.event.publisher.core.internal.type.text.TextOutputMapperFactory;
@@ -55,6 +56,7 @@ public class EventPublisherServiceValueHolder {
         mappingFactoryMap.put(MessageType.WSO2EVENT, new WSO2EventOutputMapperFactory());
         mappingFactoryMap.put(MessageType.XML, new XMLOutputMapperFactory());
         mappingFactoryMap.put(MessageType.JSON, new JSONOutputMapperFactory());
+        mappingFactoryMap.put(MessageType.FORM, new FormOutputMapperFactory());
     }
 
     private EventPublisherServiceValueHolder() {

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/type/form/FormOutputMapper.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/type/form/FormOutputMapper.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.event.publisher.core.internal.type.form;
+
+import org.wso2.carbon.databridge.commons.Attribute;
+import org.wso2.carbon.databridge.commons.StreamDefinition;
+import org.wso2.carbon.event.publisher.core.config.EventPublisherConfiguration;
+import org.wso2.carbon.event.publisher.core.config.EventPublisherConstants;
+import org.wso2.carbon.event.publisher.core.config.mapping.FormOutputMapping;
+import org.wso2.carbon.event.publisher.core.exception.EventPublisherConfigurationException;
+import org.wso2.carbon.event.publisher.core.internal.OutputMapper;
+import org.wso2.carbon.event.publisher.core.internal.util.EventPublisherUtil;
+import org.wso2.carbon.event.publisher.core.internal.util.RuntimeResourceLoader;
+import org.wso2.siddhi.core.event.Event;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This is the Output mapper class for form url encoded output type.
+ */
+public class FormOutputMapper implements OutputMapper {
+
+    private List<String> mappingTextList;
+    private EventPublisherConfiguration eventPublisherConfiguration = null;
+    private Map<String, Integer> propertyPositionMap = null;
+    private final StreamDefinition streamDefinition;
+    private final RuntimeResourceLoader runtimeResourceLoader;
+    private final boolean isCustomMappingEnabled;
+    private final String mappingText;
+
+    public FormOutputMapper(EventPublisherConfiguration eventPublisherConfiguration,
+                            Map<String, Integer> propertyPositionMap, int tenantId, StreamDefinition streamDefinition)
+            throws EventPublisherConfigurationException {
+
+        this.eventPublisherConfiguration = eventPublisherConfiguration;
+        this.propertyPositionMap = propertyPositionMap;
+        this.streamDefinition = streamDefinition;
+
+        FormOutputMapping outputMapping = (FormOutputMapping) eventPublisherConfiguration.getOutputMapping();
+        this.runtimeResourceLoader = new RuntimeResourceLoader(outputMapping.getCacheTimeoutDuration(),
+                propertyPositionMap);
+        this.isCustomMappingEnabled = outputMapping.isCustomMappingEnabled();
+
+        if (this.isCustomMappingEnabled) {
+            this.mappingText = getCustomMappingText();
+        } else {
+            this.mappingText = generateFormEventTemplate(streamDefinition);
+        }
+
+        if (!outputMapping.isRegistryResource()) {
+            this.mappingTextList = generateMappingTextList(this.mappingText);
+        }
+    }
+
+    private List<String> generateMappingTextList(String mappingText) {
+
+        List<String> mappingTextList = new ArrayList<String>();
+        List<String> textList = Arrays.asList(mappingText.trim().split(","));
+        textList.replaceAll(String::trim);
+        String text = String.join("&", textList);
+
+        mappingTextList.clear();
+        while (text.contains(EventPublisherConstants.TEMPLATE_EVENT_ATTRIBUTE_PREFIX) && text.indexOf(
+                EventPublisherConstants.TEMPLATE_EVENT_ATTRIBUTE_POSTFIX) > 0) {
+            mappingTextList.add(text.substring(0, text.indexOf(
+                    EventPublisherConstants.TEMPLATE_EVENT_ATTRIBUTE_PREFIX)).trim());
+            mappingTextList.add(text.substring(text.indexOf(EventPublisherConstants.TEMPLATE_EVENT_ATTRIBUTE_PREFIX)
+                    + 2, text.indexOf(EventPublisherConstants.TEMPLATE_EVENT_ATTRIBUTE_POSTFIX)).trim());
+            text = text.substring(text.indexOf(EventPublisherConstants.TEMPLATE_EVENT_ATTRIBUTE_POSTFIX) + 2);
+        }
+        if (!text.isEmpty()) {
+            mappingTextList.add(text.trim());
+        }
+        return mappingTextList;
+    }
+
+    @Override
+    public Object convertToMappedInputEvent(Event event)
+            throws EventPublisherConfigurationException {
+
+        if (this.isCustomMappingEnabled) {
+            EventPublisherUtil.validateStreamDefinitionWithOutputProperties(mappingText, propertyPositionMap,
+                    event.getArbitraryDataMap());
+        }
+
+        StringBuilder eventText = new StringBuilder(mappingTextList.get(0));
+        for (int i = 1; i < mappingTextList.size(); i++) {
+            if (i % 2 == 0) {
+                eventText.append(mappingTextList.get(i));
+            } else {
+                eventText.append(getPropertyValue(event, mappingTextList.get(i)));
+            }
+        }
+
+        if (!this.isCustomMappingEnabled) {
+            Map<String, Object> arbitraryDataMap = event.getArbitraryDataMap();
+            if (arbitraryDataMap != null && !arbitraryDataMap.isEmpty()) {
+                // Add arbitrary data map to the default template
+                eventText.append(EventPublisherConstants.EVENT_ATTRIBUTE_SEPARATOR);
+                for (Map.Entry<String, Object> entry : arbitraryDataMap.entrySet()) {
+                    eventText.append(entry.getKey() + EventPublisherConstants.EVENT_FORM_ATTRIBUTE_VALUE_SEPARATOR +
+                            entry.getValue() + EventPublisherConstants.EVENT_ATTRIBUTE_SEPARATOR);
+                }
+                eventText.deleteCharAt(eventText.lastIndexOf(EventPublisherConstants.EVENT_ATTRIBUTE_SEPARATOR));
+            }
+        }
+        return eventText.toString();
+    }
+
+    @Override
+    public Object convertToTypedInputEvent(Event event)
+            throws EventPublisherConfigurationException {
+
+        return convertToMappedInputEvent(event);
+    }
+
+    private String getCustomMappingText() throws EventPublisherConfigurationException {
+
+        FormOutputMapping formOutputMapping = ((FormOutputMapping) eventPublisherConfiguration.getOutputMapping());
+        String actualMappingText = formOutputMapping.getMappingText();
+        if (actualMappingText == null) {
+            throw new EventPublisherConfigurationException("Form mapping text is empty!");
+        }
+        return actualMappingText;
+    }
+
+    private Object getPropertyValue(Event event, String mappingProperty) throws EventPublisherConfigurationException {
+
+        Object[] eventData = event.getData();
+        Map<String, Object> arbitraryMap = event.getArbitraryDataMap();
+        Integer position = propertyPositionMap.get(mappingProperty);
+        Object data = null;
+
+        if (position != null && eventData.length != 0) {
+            data = eventData[position];
+        } else if (mappingProperty != null && arbitraryMap != null && arbitraryMap.containsKey(mappingProperty)) {
+            data = arbitraryMap.get(mappingProperty);
+        }
+        if (data != null) {
+            try {
+                return URLEncoder.encode(data.toString(), StandardCharsets.UTF_8.toString());
+            } catch (UnsupportedEncodingException e) {
+                throw new EventPublisherConfigurationException("Error while encoding.");
+            }
+        }
+        return "";
+    }
+
+    private String generateFormEventTemplate(StreamDefinition streamDefinition) {
+
+        String templateTextEvent = "";
+
+        List<Attribute> metaDatAttributes = streamDefinition.getMetaData();
+        if (metaDatAttributes != null && metaDatAttributes.size() > 0) {
+            for (Attribute attribute : metaDatAttributes) {
+                templateTextEvent += EventPublisherConstants.PROPERTY_META_PREFIX +
+                        attribute.getName() + EventPublisherConstants.EVENT_FORM_ATTRIBUTE_VALUE_SEPARATOR +
+                        EventPublisherConstants.TEMPLATE_EVENT_ATTRIBUTE_PREFIX +
+                        EventPublisherConstants.PROPERTY_META_PREFIX + attribute.getName() +
+                        EventPublisherConstants.TEMPLATE_EVENT_ATTRIBUTE_POSTFIX +
+                        EventPublisherConstants.EVENT_ATTRIBUTE_SEPARATOR;
+            }
+        }
+
+        List<Attribute> correlationAttributes = streamDefinition.getCorrelationData();
+        if (correlationAttributes != null && correlationAttributes.size() > 0) {
+            for (Attribute attribute : correlationAttributes) {
+                templateTextEvent += EventPublisherConstants.PROPERTY_CORRELATION_PREFIX + attribute.getName() +
+                        EventPublisherConstants.EVENT_FORM_ATTRIBUTE_VALUE_SEPARATOR +
+                        EventPublisherConstants.TEMPLATE_EVENT_ATTRIBUTE_PREFIX +
+                        EventPublisherConstants.PROPERTY_CORRELATION_PREFIX + attribute.getName() +
+                        EventPublisherConstants.TEMPLATE_EVENT_ATTRIBUTE_POSTFIX +
+                        EventPublisherConstants.EVENT_ATTRIBUTE_SEPARATOR;
+            }
+        }
+
+        List<Attribute> payloadAttributes = streamDefinition.getPayloadData();
+        if (payloadAttributes != null && payloadAttributes.size() > 0) {
+            for (Attribute attribute : payloadAttributes) {
+                templateTextEvent += attribute.getName() +
+                        EventPublisherConstants.EVENT_FORM_ATTRIBUTE_VALUE_SEPARATOR +
+                        EventPublisherConstants.TEMPLATE_EVENT_ATTRIBUTE_PREFIX + attribute.getName() +
+                        EventPublisherConstants.TEMPLATE_EVENT_ATTRIBUTE_POSTFIX +
+                        EventPublisherConstants.EVENT_ATTRIBUTE_SEPARATOR;
+            }
+        }
+        if (templateTextEvent.trim().endsWith(EventPublisherConstants.EVENT_ATTRIBUTE_SEPARATOR)) {
+            templateTextEvent = templateTextEvent.substring(0, templateTextEvent.length() - 1).trim();
+        }
+
+        return templateTextEvent;
+    }
+}

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/type/form/FormOutputMapperConfigurationBuilder.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/type/form/FormOutputMapperConfigurationBuilder.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.event.publisher.core.internal.type.form;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
+import org.wso2.carbon.event.publisher.core.config.EventPublisherConstants;
+import org.wso2.carbon.event.publisher.core.config.OutputMapping;
+import org.wso2.carbon.event.publisher.core.config.mapping.FormOutputMapping;
+import org.wso2.carbon.event.publisher.core.exception.EventPublisherConfigurationException;
+
+import javax.xml.namespace.QName;
+import java.util.Iterator;
+
+/**
+ * This is the configuration builder class for the Form output mapper.
+ */
+public class FormOutputMapperConfigurationBuilder {
+
+    private FormOutputMapperConfigurationBuilder() {
+
+    }
+
+    public static OutputMapping fromOM(OMElement mappingElement) throws EventPublisherConfigurationException {
+
+        FormOutputMapping formOutputMapping = new FormOutputMapping();
+        String customMappingEnabled = mappingElement.getAttributeValue(new QName(
+                EventPublisherConstants.EF_ATTR_CUSTOM_MAPPING));
+        if (customMappingEnabled == null || (customMappingEnabled.equals(EventPublisherConstants.ENABLE_CONST))) {
+            formOutputMapping.setCustomMappingEnabled(true);
+            if (!validateFormEventMapping(mappingElement)) {
+                throw new EventPublisherConfigurationException("FORM Mapping is not valid, check the output mapping");
+            }
+
+            OMElement innerMappingElement = mappingElement.getFirstChildWithName(
+                    new QName(EventPublisherConstants.EF_CONF_NS, EventPublisherConstants.EF_ELE_MAPPING_INLINE));
+            if (innerMappingElement != null) {
+                formOutputMapping.setRegistryResource(false);
+            } else {
+                throw new EventPublisherConfigurationException("Form Mapping is not valid, Mapping should be inline");
+            }
+
+            if (innerMappingElement.getText() == null || innerMappingElement.getText().trim().isEmpty()) {
+                throw new EventPublisherConfigurationException("No mapping content available");
+
+            } else {
+                formOutputMapping.setMappingText(innerMappingElement.getText());
+            }
+        } else {
+            formOutputMapping.setCustomMappingEnabled(false);
+        }
+        return formOutputMapping;
+    }
+
+    public static boolean validateFormEventMapping(OMElement omElement) {
+
+        int count = 0;
+        Iterator<OMElement> mappingIterator = omElement.getChildElements();
+        while (mappingIterator.hasNext()) {
+            count++;
+            mappingIterator.next();
+        }
+
+        return count != 0;
+
+    }
+
+    public static OMElement outputMappingToOM(OutputMapping outputMapping, OMFactory factory) {
+
+        FormOutputMapping formOutputMapping = (FormOutputMapping) outputMapping;
+
+        OMElement mappingOMElement = factory.createOMElement(new QName(EventPublisherConstants.EF_ELEMENT_MAPPING));
+        mappingOMElement.declareDefaultNamespace(EventPublisherConstants.EF_CONF_NS);
+
+        mappingOMElement.addAttribute(EventPublisherConstants.EF_ATTR_TYPE,
+                EventPublisherConstants.EF_FORM_MAPPING_TYPE, null);
+
+        if (formOutputMapping.isCustomMappingEnabled()) {
+            mappingOMElement.addAttribute(EventPublisherConstants.EF_ATTR_CUSTOM_MAPPING,
+                    EventPublisherConstants.ENABLE_CONST, null);
+
+            OMElement innerMappingElement = factory.createOMElement(new QName(
+                        EventPublisherConstants.EF_ELE_MAPPING_INLINE));
+            innerMappingElement.declareDefaultNamespace(EventPublisherConstants.EF_CONF_NS);
+
+            mappingOMElement.addChild(innerMappingElement);
+            innerMappingElement.setText(formOutputMapping.getMappingText());
+        } else {
+            mappingOMElement.addAttribute(EventPublisherConstants.EF_ATTR_CUSTOM_MAPPING,
+                    EventPublisherConstants.TM_VALUE_DISABLE, null);
+        }
+
+        return mappingOMElement;
+    }
+}

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/type/form/FormOutputMapperFactory.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/type/form/FormOutputMapperFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.event.publisher.core.internal.type.form;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
+import org.wso2.carbon.databridge.commons.StreamDefinition;
+import org.wso2.carbon.event.publisher.core.config.EventPublisherConfiguration;
+import org.wso2.carbon.event.publisher.core.config.OutputMapperFactory;
+import org.wso2.carbon.event.publisher.core.config.OutputMapping;
+import org.wso2.carbon.event.publisher.core.exception.EventPublisherConfigurationException;
+import org.wso2.carbon.event.publisher.core.internal.OutputMapper;
+
+import java.util.Map;
+
+/**
+ * The factory class to create a FormOutputMapper.
+ */
+public class FormOutputMapperFactory implements OutputMapperFactory {
+
+    @Override
+    public OutputMapping constructOutputMapping(OMElement omElement)
+            throws EventPublisherConfigurationException {
+
+        return FormOutputMapperConfigurationBuilder.fromOM(omElement);
+    }
+
+    @Override
+    public OMElement constructOMFromOutputMapping(OutputMapping outputMapping, OMFactory factory) {
+
+        return FormOutputMapperConfigurationBuilder.outputMappingToOM(outputMapping, factory);
+    }
+
+    @Override
+    public OutputMapper constructOutputMapper(EventPublisherConfiguration eventPublisherConfiguration,
+            Map<String, Integer> propertyPositionMap, int tenantId, StreamDefinition streamDefinition)
+            throws EventPublisherConfigurationException {
+
+        return new FormOutputMapper(eventPublisherConfiguration, propertyPositionMap, tenantId, streamDefinition);
+    }
+}

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/util/EventPublisherConfigurationBuilder.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/util/EventPublisherConfigurationBuilder.java
@@ -240,6 +240,10 @@ public class EventPublisherConfigurationBuilder {
             if (!validateSupportedMapping(toEventAdapterType, MessageType.JSON)) {
                 throw new EventPublisherConfigurationException("JSON Mapping is not supported by event adapter type " + toEventAdapterType);
             }
+        } else if (mappingType.equalsIgnoreCase(EventPublisherConstants.EF_FORM_MAPPING_TYPE)) {
+            if (!validateSupportedMapping(toEventAdapterType, MessageType.FORM)) {
+                throw new EventPublisherConfigurationException("Form Mapping is not supported by event adapter type " + toEventAdapterType);
+            }
         } else {
             String factoryClassName = getMappingTypeFactoryClass(mappingElement);
             if (factoryClassName == null) {

--- a/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf/output-event-adapters.xml
+++ b/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf/output-event-adapters.xml
@@ -61,6 +61,8 @@
         <!-- HTTP Client Pool Related Properties -->
         <property key="defaultMaxConnectionsPerHost">50</property>
         <property key="maxTotalConnections">1000</property>
+        <!-- Property to enable x-www-form-urlencoded payloads -->
+        <property key="enableFormUrlEncoded">false</property>
     </adapterConfig>
 
     <adapterConfig type="jms">

--- a/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/templates/repository/conf/output-event-adapters.xml.j2
+++ b/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/templates/repository/conf/output-event-adapters.xml.j2
@@ -61,6 +61,8 @@
         <!-- HTTP Client Pool Related Properties -->
         <property key="defaultMaxConnectionsPerHost">50</property>
         <property key="maxTotalConnections">1000</property>
+        <!-- Property to enable x-www-form-urlencoded payloads -->
+        <property key="enableFormUrlEncoded">false</property>
     </adapterConfig>
 
     <adapterConfig type="jms">


### PR DESCRIPTION
## Purpose

- As of the current implementation, the HTTP Event Adapter is only supporting JSON, XML, and text payloads and does not support x-www-form-urlencoded payloads.  
- This PR improves the adapter implementation to support x-www-form-urlencoded payloads.
- To give support for x-www-form-urlencoded payload, we need to add the following configuration to the output-event-adapters.xml file. The default value is `false`

  -   ``` enableFormUrlEncoded = true  ```

- The configuration XML file of the above form mapping is as follows.

``` 
<eventPublisher ... xmlns="http://wso2.org/carbon/eventpublisher">
  <from ... />
  <mapping customMapping="enable" type="text">
    <inline>data1=value1,data2=value2,data3=value3</inline>
  </mapping>
  <to ... />
</eventPublisher> 
 ```

