### PR TITLE
Improve HttpEventAdaptor logs 

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/HTTPEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/HTTPEventAdapter.java
@@ -333,7 +333,7 @@ public class HTTPEventAdapter implements OutputEventAdapter {
                 int responseCode = this.getHttpClient().executeMethod(hostConfiguration, method);
                 if (responseCode / 100 == 2) {
                     if (log.isDebugEnabled()) {
-                        log.info("Successfully connected to the endpoint. Received HTTP response code is : " +
+                        log.debug("Successfully connected to the endpoint. Received HTTP response code is : " +
                                 responseCode);
                     }
                 } else {

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/HTTPEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/HTTPEventAdapter.java
@@ -330,8 +330,16 @@ public class HTTPEventAdapter implements OutputEventAdapter {
                     }
                 }
 
-                this.getHttpClient().executeMethod(hostConfiguration, method);
-
+                int responseCode = this.getHttpClient().executeMethod(hostConfiguration, method);
+                if (responseCode / 100 == 2) {
+                    if (log.isDebugEnabled()) {
+                        log.info("Successfully connected to the endpoint. Received HTTP response code is : " +
+                                responseCode);
+                    }
+                } else {
+                    log.error("Error while connecting the endpoint. Received HTTP response code is : " +
+                            responseCode + " Error details : " + new String(method.getResponseBody()));
+                }
             } catch (UnknownHostException e) {
                 EventAdapterUtil.logAndDrop(eventAdapterConfiguration.getName(), this.getPayload(),
                         "Cannot connect to " + this.getUrl(), e, log, tenantId);

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/HTTPEventAdapterFactory.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/HTTPEventAdapterFactory.java
@@ -125,7 +125,10 @@ public class HTTPEventAdapterFactory extends OutputEventAdapterFactory {
 
         Map<String, String> globalProperties = EventAdapterUtil.
                 getGlobalProperties(HTTPEventAdapterConstants.ADAPTER_TYPE_HTTP);
-        return Boolean
-                .parseBoolean(globalProperties.get(HTTPEventAdapterConstants.ENABLE_FORM_URL_ENCODED));
+        if (globalProperties != null) {
+            return Boolean
+                    .parseBoolean(globalProperties.get(HTTPEventAdapterConstants.ENABLE_FORM_URL_ENCODED));
+        }
+        return false;
     }
 }

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/HTTPEventAdapterFactory.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.http/src/main/java/org/wso2/carbon/event/output/adapter/http/HTTPEventAdapterFactory.java
@@ -125,10 +125,7 @@ public class HTTPEventAdapterFactory extends OutputEventAdapterFactory {
 
         Map<String, String> globalProperties = EventAdapterUtil.
                 getGlobalProperties(HTTPEventAdapterConstants.ADAPTER_TYPE_HTTP);
-        if (globalProperties != null) {
-            return Boolean
-                    .parseBoolean(globalProperties.get(HTTPEventAdapterConstants.ENABLE_FORM_URL_ENCODED));
-        }
-        return false;
+        return globalProperties != null && Boolean
+                .parseBoolean(globalProperties.get(HTTPEventAdapterConstants.ENABLE_FORM_URL_ENCODED));
     }
 }


### PR DESCRIPTION
## Purpose
In the current implementation of the adapter, response codes are not handled and due to that runtime errors can not be troubleshooted. Hence we need to improve the current adapter to log detailed errors for troubleshooting purposes .