### PR TITLE
Add secret resolve support

### DIFF
--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/pom.xml
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/pom.xml
@@ -73,6 +73,11 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.securevault</groupId>
+            <artifactId>org.wso2.securevault</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1520,7 +1520,7 @@
         <carbon.kernel.version>4.5.3</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <!--<carbon.kernel.imp.pkg.version>[4.3.0, 4.4.0)</carbon.kernel.imp.pkg.version>-->
-        <securevault.wso2.version>1.1.3</securevault.wso2.version>
+        <securevault.wso2.version>1.1.5</securevault.wso2.version>
 
         <carbon.commons.version>4.7.19</carbon.commons.version>
         <!--<carbon.deployment.version>4.3.1</carbon.deployment.version>-->


### PR DESCRIPTION
## Purpose

When using encrypted secrets with cipher tool, current implementation of EventPublisherConfigurationBuilder doesn't support to resolve the secret. This PR fixes it by iterating through each dynamic properties and replacing only the $secret{key} fragment with the decrypted secret.