### PR TITLE
[5.3.x] Add HA and Distributed Variables to Carbon.Analytics.Commons

### DIFF
--- a/components/event-processor-manager/org.wso2.carbon.event.processor.manager.core/src/main/java/org/wso2/carbon/event/processor/manager/core/config/Mode.java
+++ b/components/event-processor-manager/org.wso2.carbon.event.processor.manager.core/src/main/java/org/wso2/carbon/event/processor/manager/core/config/Mode.java
@@ -19,5 +19,5 @@
 package org.wso2.carbon.event.processor.manager.core.config;
 
 public enum Mode {
-    SingleNode
+    SingleNode, HA, Distributed
 }


### PR DESCRIPTION
## Purpose
Even though we are not using HA and Distributed, carbon.event.processing access those variables while building. So if we are bumping carbon.event.processing with carbon.analytics.commons : 5.3.x which does not contain HA and Distributed, having these variables in carbon.analytics.commons or doing code changes in carbon.event.processing is a must to avoid any building errors. 