### PR TITLE
Improve re connection to data endpoints based on configurable values.

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.databridge.agent;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.databridge.agent.conf.AgentConfiguration;
 import org.wso2.carbon.databridge.agent.conf.DataEndpointConfiguration;
 import org.wso2.carbon.databridge.agent.endpoint.DataEndpoint;
 import org.wso2.carbon.databridge.agent.endpoint.DataEndpointGroup;
@@ -174,6 +175,7 @@ public class DataPublisher {
             for (int j = 1; j < receiverGroup.length; j++) {
                 DataEndpointConfiguration endpointConfiguration;
                 String[] urlParams = DataPublisherUtil.getProtocolHostPort((String) receiverGroup[j]);
+                AgentConfiguration agentConfiguration = dataEndpointAgent.getAgentConfiguration();
 
                 if (urlParams[0].equalsIgnoreCase(DataEndpointConfiguration.Protocol.TCP.toString())) {
                     endpointConfiguration = new DataEndpointConfiguration((String) receiverGroup[j],
@@ -184,7 +186,8 @@ public class DataPublisher {
                             dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
                             dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool(),
                             dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds(),
-                            failOver);
+                            failOver, agentConfiguration.getReconnectionInterval(), agentConfiguration.getExpFactor(),
+                            agentConfiguration.getMaxDelayInSeconds());
                 } else {
                     endpointConfiguration = new DataEndpointConfiguration((String) receiverGroup[j],
                             (String) authGroup[j], username, password, dataEndpointAgent.getSecuredTransportPool(),
@@ -194,7 +197,8 @@ public class DataPublisher {
                             dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
                             dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool(),
                             dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds(),
-                            failOver);
+                            failOver,  agentConfiguration.getReconnectionInterval(), agentConfiguration.getExpFactor(),
+                            agentConfiguration.getMaxDelayInSeconds());
                 }
                 DataEndpoint dataEndpoint = dataEndpointAgent.getNewDataEndpoint();
                 dataEndpoint.initialize(endpointConfiguration);

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/AgentConfiguration.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/AgentConfiguration.java
@@ -44,14 +44,6 @@ public class AgentConfiguration {
 
     private int reconnectionInterval;
 
-    public void setExpFactor(int expFactor) {
-        this.expFactor = expFactor;
-    }
-
-    public void setMaxDelayInSeconds(int maxDelayInSeconds) {
-        this.maxDelayInSeconds = maxDelayInSeconds;
-    }
-
     private int expFactor;
 
     private int maxDelayInSeconds;
@@ -147,9 +139,17 @@ public class AgentConfiguration {
         return reconnectionInterval;
     }
 
+    public void setReconnectionInterval(int reconnectionInterval) {
+        this.reconnectionInterval = reconnectionInterval;
+    }
+
     @XmlElement(name = "ExpFactor")
     public int getExpFactor() {
         return expFactor;
+    }
+
+    public void setExpFactor(int expFactor) {
+        this.expFactor = expFactor;
     }
 
     @XmlElement(name = "MaxReconnectionInterval")
@@ -157,8 +157,8 @@ public class AgentConfiguration {
         return maxDelayInSeconds;
     }
 
-    public void setReconnectionInterval(int reconnectionInterval) {
-        this.reconnectionInterval = reconnectionInterval;
+    public void setMaxDelayInSeconds(int maxDelayInSeconds) {
+        this.maxDelayInSeconds = maxDelayInSeconds;
     }
 
     @XmlElement(name = "MaxTransportPoolSize")

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/AgentConfiguration.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/AgentConfiguration.java
@@ -44,6 +44,18 @@ public class AgentConfiguration {
 
     private int reconnectionInterval;
 
+    public void setExpFactor(int expFactor) {
+        this.expFactor = expFactor;
+    }
+
+    public void setMaxDelayInSeconds(int maxDelayInSeconds) {
+        this.maxDelayInSeconds = maxDelayInSeconds;
+    }
+
+    private int expFactor;
+
+    private int maxDelayInSeconds;
+
     private int queueSize;
 
     private int batchSize;
@@ -133,6 +145,16 @@ public class AgentConfiguration {
     @XmlElement(name = "ReconnectionInterval")
     public int getReconnectionInterval() {
         return reconnectionInterval;
+    }
+
+    @XmlElement(name = "ExpFactor")
+    public int getExpFactor() {
+        return expFactor;
+    }
+
+    @XmlElement(name = "MaxReconnectionInterval")
+    public int getMaxDelayInSeconds() {
+        return maxDelayInSeconds;
     }
 
     public void setReconnectionInterval(int reconnectionInterval) {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/DataEndpointConfiguration.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/DataEndpointConfiguration.java
@@ -52,6 +52,27 @@ public class DataEndpointConfiguration {
 
     private boolean failOverEndpoint;
 
+    public int getReconnectionInterval() {
+        return reconnectionInterval;
+    }
+
+    public int getExpFactor() {
+        return expFactor;
+    }
+
+    public int getMaxDelayInSeconds() {
+        return maxDelayInSeconds;
+    }
+
+    private int reconnectionInterval;
+
+    public void setExpFactor(int expFactor) {
+        this.expFactor = expFactor;
+    }
+
+    private int expFactor;
+    private int maxDelayInSeconds;
+
     public enum Protocol {
         TCP, SSL;
 
@@ -65,7 +86,8 @@ public class DataEndpointConfiguration {
                                      GenericKeyedObjectPool transportPool,
                                      GenericKeyedObjectPool securedTransportPool,
                                      int batchSize, int corePoolSize, int maxPoolSize, int keepAliveTimeInPool,
-                                     int loggingControlIntervalInSeconds, boolean failOverEndpoint) {
+                                     int loggingControlIntervalInSeconds, boolean failOverEndpoint,
+                                     int reconnectionInterval, int expFactor, int maxDelayInSeconds) {
         this.receiverURL = receiverURL;
         this.authURL = authURL;
         this.username = username;
@@ -80,6 +102,9 @@ public class DataEndpointConfiguration {
         this.keepAliveTimeInPool = keepAliveTimeInPool;
         this.loggingControlIntervalInSeconds = (long) loggingControlIntervalInSeconds;
         this.failOverEndpoint = failOverEndpoint;
+        this.reconnectionInterval = reconnectionInterval;
+        this.expFactor = expFactor;
+        this.maxDelayInSeconds = maxDelayInSeconds;
     }
 
     public String getReceiverURL() {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/DataEndpointConfiguration.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/DataEndpointConfiguration.java
@@ -52,6 +52,12 @@ public class DataEndpointConfiguration {
 
     private boolean failOverEndpoint;
 
+    private int reconnectionInterval;
+
+    private int expFactor;
+
+    private int maxDelayInSeconds;
+
     public int getReconnectionInterval() {
         return reconnectionInterval;
     }
@@ -64,14 +70,9 @@ public class DataEndpointConfiguration {
         return maxDelayInSeconds;
     }
 
-    private int reconnectionInterval;
-
     public void setExpFactor(int expFactor) {
         this.expFactor = expFactor;
     }
-
-    private int expFactor;
-    private int maxDelayInSeconds;
 
     public enum Protocol {
         TCP, SSL;

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
@@ -64,6 +64,26 @@ public abstract class DataEndpoint {
 
     private List<Event> events;
 
+
+    public long getReConnectTimestamp() {
+        return reConnectTimestamp;
+    }
+
+    public void setReConnectTimestamp(long reConnectTimestamp) {
+        this.reConnectTimestamp = reConnectTimestamp;
+    }
+
+    public long reConnectTimestamp = 0;
+
+    public static long getDelay() {
+        return delay;
+    }
+
+    public static void setDelay(long delay) {
+        DataEndpoint.delay = delay;
+    }
+
+    public static long delay = 0;
     private State state;
 
     private Semaphore immediateDispatchSemaphore;
@@ -139,7 +159,7 @@ public abstract class DataEndpoint {
             throws TransportException,
             DataEndpointAuthenticationException, DataEndpointException {
         if (connectionWorker != null) {
-            connectionService.submit(connectionWorker);
+           connectionWorker.be(true);
         } else {
             throw new DataEndpointException("Data Endpoint is not initialized");
         }
@@ -148,7 +168,7 @@ public abstract class DataEndpoint {
     synchronized void syncConnect(String oldSessionId) throws DataEndpointException {
         if (oldSessionId == null || oldSessionId.equalsIgnoreCase(getDataEndpointConfiguration().getSessionId())) {
             if (connectionWorker != null) {
-                connectionWorker.run();
+                connectionWorker.be(false);
             } else {
                 throw new DataEndpointException("Data Endpoint is not initialized");
             }

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.databridge.commons.exception.UndefinedEventTypeException;
 import org.wso2.carbon.databridge.commons.utils.DataBridgeThreadFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -74,16 +75,7 @@ public abstract class DataEndpoint {
     }
 
     public long reConnectTimestamp = 0;
-
-    public static long getDelay() {
-        return delay;
-    }
-
-    public static void setDelay(long delay) {
-        DataEndpoint.delay = delay;
-    }
-
-    public static long delay = 0;
+    public static HashMap<String, Long> delayMap=new HashMap<String, Long>();
     private State state;
 
     private Semaphore immediateDispatchSemaphore;
@@ -159,7 +151,7 @@ public abstract class DataEndpoint {
             throws TransportException,
             DataEndpointAuthenticationException, DataEndpointException {
         if (connectionWorker != null) {
-           connectionWorker.be(true);
+           connectionWorker.runConnection(true);
         } else {
             throw new DataEndpointException("Data Endpoint is not initialized");
         }
@@ -168,7 +160,7 @@ public abstract class DataEndpoint {
     synchronized void syncConnect(String oldSessionId) throws DataEndpointException {
         if (oldSessionId == null || oldSessionId.equalsIgnoreCase(getDataEndpointConfiguration().getSessionId())) {
             if (connectionWorker != null) {
-                connectionWorker.be(false);
+                connectionWorker.runConnection(false);
             } else {
                 throw new DataEndpointException("Data Endpoint is not initialized");
             }

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
@@ -65,6 +65,11 @@ public abstract class DataEndpoint {
 
     private List<Event> events;
 
+    private State state;
+
+    public long reConnectTimestamp = 0;
+
+    public static HashMap<String, Long> delayMap=new HashMap<String, Long>();
 
     public long getReConnectTimestamp() {
         return reConnectTimestamp;
@@ -74,9 +79,13 @@ public abstract class DataEndpoint {
         this.reConnectTimestamp = reConnectTimestamp;
     }
 
-    public long reConnectTimestamp = 0;
-    public static HashMap<String, Long> delayMap=new HashMap<String, Long>();
-    private State state;
+    public static HashMap<String, Long> getDelayMap() {
+        return delayMap;
+    }
+
+    public static void setDelayMap(HashMap<String, Long> delayMap) {
+        DataEndpoint.delayMap = delayMap;
+    }
 
     private Semaphore immediateDispatchSemaphore;
 

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointConnectionWorker.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointConnectionWorker.java
@@ -90,23 +90,33 @@ public class DataEndpointConnectionWorker {
                     }
                     dataEndpoint.setReConnectTimestamp(System.currentTimeMillis() +
                             dataEndpoint.delayMap.get(receiverURL));
-                    log.warn("Next Reconnection attempt to Data endpoint : " +
-                            dataEndpoint.getDataEndpointConfiguration().getReceiverURL() +
-                            " will be after " + dataEndpoint.delayMap.get(receiverURL) / 1000 + " seconds");
                 }
                 if (isLoggingControl) {
                     if (loggingControlFlag.get()) {
                         if (dataEndpointConfiguration.isFailOverEndpoint()) {
                             log.info("Attempt to connect to the endpoint " +
-                                    dataEndpoint.getDataEndpointConfiguration().getAuthURL() + " failed.");
+                                dataEndpoint.getDataEndpointConfiguration().getAuthURL() + " failed." + " " +
+                                "Next Reconnection attempt to Data endpoint : " +
+                                dataEndpoint.getDataEndpointConfiguration().getReceiverURL() +
+                                " will be after " + dataEndpoint.delayMap.get(receiverURL) / 1000 + " seconds");
                             log.debug("Error while trying to connect to the endpoint. " + e.getErrorMessage(), e);
                         } else {
                             log.error("Error while trying to connect to the endpoint. " + e.getErrorMessage(), e);
+                            if(reconnect) {
+                                log.warn("Next Reconnection attempt to Data endpoint : " +
+                                    dataEndpoint.getDataEndpointConfiguration().getReceiverURL() +
+                                    " will be after " + dataEndpoint.delayMap.get(receiverURL) / 1000 + " seconds");
+                            }
                         }
                         loggingControlFlag.set(false);
                     }
                 } else {
                     log.error("Error while trying to connect to the endpoint. " + e.getErrorMessage(), e);
+                    if(reconnect) {
+                        log.warn("Next Reconnection attempt to Data endpoint : " +
+                            dataEndpoint.getDataEndpointConfiguration().getReceiverURL() +
+                            " will be after " + dataEndpoint.delayMap.get(receiverURL) / 1000 + " seconds");
+                    }
                 }
                 dataEndpoint.deactivate();
             } catch (DataEndpointLoginException e) {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -467,6 +467,7 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
                         }
                     }
                 }
+                busyWait(1);
             }
         }
 

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -438,8 +438,6 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
     private class ReconnectionTask extends TimerTask {
         public void run() {
             long gap = 0;
-            long isEPCheckedGap = 0;
-            long addedDelayForEPCheck = 10000;
             for (int i = START_INDEX; i < maximumDataPublisherIndex.get(); i++) {
                 DataEndpoint dataEndpoint = dataEndpoints.get(i);
                 if (!dataEndpoint.isConnected()) {
@@ -453,13 +451,10 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
                     }
                 } else {
                     try {
-                        if (System.currentTimeMillis() > isEPCheckedGap) {
-                            isEPCheckedGap = System.currentTimeMillis() + addedDelayForEPCheck;
-                            String[] urlElements = DataPublisherUtil.getProtocolHostPort(
-                                    dataEndpoint.getDataEndpointConfiguration().getReceiverURL());
-                            if (!isServerExists(urlElements[1], Integer.parseInt(urlElements[2]))) {
-                                dataEndpoint.deactivate();
-                            }
+                        String[] urlElements = DataPublisherUtil.getProtocolHostPort(
+                                dataEndpoint.getDataEndpointConfiguration().getReceiverURL());
+                        if (!isServerExists(urlElements[1], Integer.parseInt(urlElements[2]))) {
+                            dataEndpoint.deactivate();
                         }
                     } catch (DataEndpointConfigurationException exception) {
                         log.warn("Data Endpoint with receiver URL:" +

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -42,8 +42,6 @@ import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -105,8 +103,8 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
 
         currentDataPublisherIndex.set(START_INDEX);
         ReconnectionTask reconnectionTask = new ReconnectionTask();
-        Timer timer = new Timer();
-        timer.scheduleAtFixedRate(reconnectionTask, 0, 30000);
+        reconnection = new Thread(reconnectionTask);
+        reconnection.start();
     }
 
     public void addDataEndpoint(DataEndpoint dataEndpoint) {
@@ -435,36 +433,38 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
         return unsuccessfulEvents;
     }
 
-    private class ReconnectionTask extends TimerTask {
+    private class ReconnectionTask implements Runnable {
         public void run() {
             long gap = 0;
             long isEPCheckedGap = 0;
-            long addedDelayForEPCheck = 10000;
-            for (int i = START_INDEX; i < maximumDataPublisherIndex.get(); i++) {
-                DataEndpoint dataEndpoint = dataEndpoints.get(i);
-                if (!dataEndpoint.isConnected()) {
-                    gap = System.currentTimeMillis() - dataEndpoint.getReConnectTimestamp();
-                    try {
-                        if (gap > 0) {
-                            dataEndpoint.connect();
-                        }
-                    } catch (Exception ex) {
-                        dataEndpoint.deactivate();
-                    }
-                } else {
-                    try {
-                        if (System.currentTimeMillis() > isEPCheckedGap) {
-                            isEPCheckedGap = System.currentTimeMillis() + addedDelayForEPCheck;
-                            String[] urlElements = DataPublisherUtil.getProtocolHostPort(
-                                    dataEndpoint.getDataEndpointConfiguration().getReceiverURL());
-                            if (!isServerExists(urlElements[1], Integer.parseInt(urlElements[2]))) {
-                                dataEndpoint.deactivate();
+            long addedDelayForEPCheck = 10000l;
+            while (true) {
+                for (int i = START_INDEX; i < maximumDataPublisherIndex.get(); i++) {
+                    DataEndpoint dataEndpoint = dataEndpoints.get(i);
+                    if (!dataEndpoint.isConnected()) {
+                        gap = System.currentTimeMillis() - dataEndpoint.getReConnectTimestamp();
+                        try {
+                            if (gap > 0) {
+                                dataEndpoint.connect();
                             }
+                        } catch (Exception ex) {
+                            dataEndpoint.deactivate();
                         }
-                    } catch (DataEndpointConfigurationException exception) {
-                        log.warn("Data Endpoint with receiver URL:" +
-                                dataEndpoint.getDataEndpointConfiguration().getReceiverURL()
-                                + " could not be deactivated", exception);
+                    } else {
+                        try {
+                            if (System.currentTimeMillis() > isEPCheckedGap) {
+                                isEPCheckedGap = System.currentTimeMillis() + addedDelayForEPCheck;
+                                String[] urlElements = DataPublisherUtil.getProtocolHostPort(
+                                        dataEndpoint.getDataEndpointConfiguration().getReceiverURL());
+                                if (!isServerExists(urlElements[1], Integer.parseInt(urlElements[2]))) {
+                                    dataEndpoint.deactivate();
+                                }
+                            }
+                        } catch (DataEndpointConfigurationException exception) {
+                            log.warn("Data Endpoint with receiver URL:" +
+                                    dataEndpoint.getDataEndpointConfiguration().getReceiverURL()
+                                    + " could not be deactivated", exception);
+                        }
                     }
                 }
             }

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -441,10 +441,6 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
             while (true) {
                 for (int i = START_INDEX; i < maximumDataPublisherIndex.get(); i++) {
                     DataEndpoint dataEndpoint = dataEndpoints.get(i);
-                    try {
-                        TimeUnit.MILLISECONDS.sleep(10);
-                    } catch (InterruptedException ignored) {
-                    }
                     if (!dataEndpoint.isConnected()) {
                         gap = System.currentTimeMillis() - dataEndpoint.getReConnectTimestamp();
                         try {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -75,17 +75,6 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
 
     private ExecutorService reconnectionService;
 
-
-    public static long getDelay() {
-        return delay;
-    }
-
-    public static void setDelay(long delay) {
-        DataEndpointGroup.delay = delay;
-    }
-
-    static long delay;
-
     private final String publishingStrategy;
 
     private boolean isShutdown = false;
@@ -123,9 +112,6 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
         ReconnectionTask reconnectionTask = new ReconnectionTask();
         Thread reconnection = new Thread(reconnectionTask);
         reconnection.start();
-
-        /*this.reconnectionService.scheduleAtFixedRate(new ReconnectionTask(), reconnectionInterval,
-                reconnectionInterval, TimeUnit.SECONDS);*/
     }
 
     public void addDataEndpoint(DataEndpoint dataEndpoint) {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -436,6 +436,8 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
     private class ReconnectionTask implements Runnable {
         public void run() {
             long gap = 0;
+            long isEPCheckedGap = 0;
+            long addedDelayForEPCheck = 10000l;
             while (true) {
                 for (int i = START_INDEX; i < maximumDataPublisherIndex.get(); i++) {
                     DataEndpoint dataEndpoint = dataEndpoints.get(i);
@@ -454,10 +456,13 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
                         }
                     } else {
                         try {
-                            String[] urlElements = DataPublisherUtil.getProtocolHostPort(
-                                    dataEndpoint.getDataEndpointConfiguration().getReceiverURL());
-                            if (!isServerExists(urlElements[1], Integer.parseInt(urlElements[2]))) {
-                                dataEndpoint.deactivate();
+                            if (System.currentTimeMillis() > isEPCheckedGap) {
+                                isEPCheckedGap = System.currentTimeMillis() + addedDelayForEPCheck;
+                                String[] urlElements = DataPublisherUtil.getProtocolHostPort(
+                                        dataEndpoint.getDataEndpointConfiguration().getReceiverURL());
+                                if (!isServerExists(urlElements[1], Integer.parseInt(urlElements[2]))) {
+                                    dataEndpoint.deactivate();
+                                }
                             }
                         } catch (DataEndpointConfigurationException exception) {
                             log.warn("Data Endpoint with receiver URL:" +

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -438,6 +438,8 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
     private class ReconnectionTask extends TimerTask {
         public void run() {
             long gap = 0;
+            long isEPCheckedGap = 0;
+            long addedDelayForEPCheck = 10000;
             for (int i = START_INDEX; i < maximumDataPublisherIndex.get(); i++) {
                 DataEndpoint dataEndpoint = dataEndpoints.get(i);
                 if (!dataEndpoint.isConnected()) {
@@ -451,10 +453,13 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
                     }
                 } else {
                     try {
-                        String[] urlElements = DataPublisherUtil.getProtocolHostPort(
-                                dataEndpoint.getDataEndpointConfiguration().getReceiverURL());
-                        if (!isServerExists(urlElements[1], Integer.parseInt(urlElements[2]))) {
-                            dataEndpoint.deactivate();
+                        if (System.currentTimeMillis() > isEPCheckedGap) {
+                            isEPCheckedGap = System.currentTimeMillis() + addedDelayForEPCheck;
+                            String[] urlElements = DataPublisherUtil.getProtocolHostPort(
+                                    dataEndpoint.getDataEndpointConfiguration().getReceiverURL());
+                            if (!isServerExists(urlElements[1], Integer.parseInt(urlElements[2]))) {
+                                dataEndpoint.deactivate();
+                            }
                         }
                     } catch (DataEndpointConfigurationException exception) {
                         log.warn("Data Endpoint with receiver URL:" +

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -440,7 +440,7 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
                 for (int i = START_INDEX; i < maximumDataPublisherIndex.get(); i++) {
                     DataEndpoint dataEndpoint = dataEndpoints.get(i);
                     try {
-                        TimeUnit.MILLISECONDS.sleep(1);
+                        TimeUnit.MILLISECONDS.sleep(10);
                     } catch (InterruptedException ignored) {
                     }
                     if (!dataEndpoint.isConnected()) {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -439,6 +439,10 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
             while (true) {
                 for (int i = START_INDEX; i < maximumDataPublisherIndex.get(); i++) {
                     DataEndpoint dataEndpoint = dataEndpoints.get(i);
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(1);
+                    } catch (InterruptedException ignored) {
+                    }
                     if (!dataEndpoint.isConnected()) {
                         gap = System.currentTimeMillis() - dataEndpoint.getReConnectTimestamp();
                         try {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/DataBrigdeWorkerTestCase.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/DataBrigdeWorkerTestCase.java
@@ -42,8 +42,8 @@ public class DataBrigdeWorkerTestCase {
 
     @Test
     public void testDataEndpointConnectionWorkerNotInitializedTest() {
-        Thread thread = new Thread(new DataEndpointConnectionWorker());
-        thread.start();
+        DataEndpointConnectionWorker dataEndpointConnectionWorker = new DataEndpointConnectionWorker();
+        dataEndpointConnectionWorker.runConnection(false);
     }
 
     @Test

--- a/features/data-bridge/org.wso2.carbon.databridge.agent.server.feature/src/main/resources/conf_templates/templates/repository/conf/data-bridge/data-agent-config.xml.j2
+++ b/features/data-bridge/org.wso2.carbon.databridge.agent.server.feature/src/main/resources/conf_templates/templates/repository/conf/data-bridge/data-agent-config.xml.j2
@@ -48,6 +48,16 @@
         {% if transport.thrift.agent.ciphers is defined %}
         <ciphers>{{transport.thrift.agent.ciphers}}</ciphers>
         {% endif %}
+        {% if transport.thrift.agent.exp_factor is defined %}
+        <ExpFactor>{{transport.thrift.agent.exp_factor}}</ExpFactor>
+        {% else %}
+        <ExpFactor>1</ExpFactor>
+        {% endif %}
+        {% if transport.thrift.agent.max_reconnection_interval is defined %}
+        <MaxReconnectionInterval>{{transport.thrift.agent.max_reconnection_interval}}</MaxReconnectionInterval>
+        {% else %}
+        <MaxReconnectionInterval>3600</MaxReconnectionInterval>
+        {% endif %}
     </Agent>
 
     <Agent>
@@ -79,6 +89,16 @@
         {% endif %}
         {% if transport.binary.agent.ciphers is defined %}
         <ciphers>{{transport.binary.agent.ciphers}}</ciphers>
+        {% endif %}
+        {% if transport.binary.agent.exp_factor is defined %}
+        <ExpFactor>{{transport.binary.agent.exp_factor}}</ExpFactor>
+        {% else %}
+        <ExpFactor>1</ExpFactor>
+        {% endif %}
+        {% if transport.binary.agent.max_reconnection_interval is defined %}
+        <MaxReconnectionInterval>{{transport.binary.agent.max_reconnection_interval}}</MaxReconnectionInterval>
+        {% else %}
+        <MaxReconnectionInterval>3600</MaxReconnectionInterval>
         {% endif %}
     </Agent>
 </DataAgentsConfiguration>


### PR DESCRIPTION
Purpose

resolves https://github.com/wso2/api-manager/issues/407

Currently the re connection to a failed data endpoints run as a scheduled service with a configurable fixed time gap. This creates lot of logs when a data endpoint goes down in regular interval and create performance impacts while trying to re connect to a endpoint on same fixed intervals. This behavior has been improved to increase the delay between each failed connection attempt exponentially through configurable value to reduce the re connection overhead of a failed endpoint.

Implementation

This is implemented with three configurable properties namely ReConnectionInterval, ExpFacto, MaxReConnectionInterval. The delay between each failed attempt will be increased by ReConnectionInterval * ExpFactor till it reaches the MaxReconnectionInterval. Once it reaches the MaxReconnectionInterval , then every other failed re connection attempts will be executed after the MaxReconnectionInterval. If a connection attempt is succesfull when the data endpoint is running again, then the re connection interval will be re set to its old configured value.

Sample Configurations

[transport.binary.agent]
reconnection_interval = 30
exp_factor=2
max_reconnection_interval = 3600

Sample Behavior with the above configurations

Request attempts

1st failed connection attempt - Adds delay of (30*2) 60 seconds for the next attempt from the current time.

2nd failed connection attempt - Adds delay of (60*2) 120 seconds for the next attempt from the current time.

3rd failed connection attempt - Adds delay of (120*2) 240 secods for the next attempt from the current time.

4th succesffull connection attempt - Resets the delay to its old value and no connection attempt will be made unless the endpoints state changes to UNAVAIABLE.

Note : If someone needs to keep the old behavior to keep retrying in the fixed intervals , then exp_factor factor should be set to 1.