### PR TITLE
Upgrade commons-io to 2.11.0

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.core/pom.xml
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/pom.xml
@@ -50,8 +50,8 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.directory.studio</groupId>
-            <artifactId>org.apache.commons.io</artifactId>
+            <groupId>commons-io.wso2</groupId>
+            <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/features/data-bridge/org.wso2.carbon.databridge.core.feature/pom.xml
+++ b/features/data-bridge/org.wso2.carbon.databridge.core.feature/pom.xml
@@ -39,8 +39,8 @@
             <artifactId>org.wso2.carbon.databridge.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.directory.studio</groupId>
-            <artifactId>org.apache.commons.io</artifactId>
+            <groupId>commons-io.wso2</groupId>
+            <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
@@ -88,8 +88,8 @@
                                     <version>${carbon.analytics.common.version}</version>
                                 </bundle>
                                 <bundle>
-                                    <symbolicName>org.apache.commons.io</symbolicName>
-                                    <version>${apache.commons.io.version}</version>
+                                    <symbolicName>commons-io</symbolicName>
+                                    <version>${commons.io.version}</version>
                                 </bundle>
                                 <bundle>
                                     <symbolicName>org.yaml.snakeyaml</symbolicName>

--- a/features/data-bridge/org.wso2.carbon.databridge.feature/pom.xml
+++ b/features/data-bridge/org.wso2.carbon.databridge.feature/pom.xml
@@ -70,8 +70,8 @@
             <artifactId>org.wso2.carbon.databridge.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.directory.studio</groupId>
-            <artifactId>org.apache.commons.io</artifactId>
+            <groupId>commons-io.wso2</groupId>
+            <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
@@ -177,8 +177,8 @@
                                     <version>${carbon.analytics.common.version}</version>
                                 </bundle>
                                 <bundle>
-                                    <symbolicName>org.apache.commons.io</symbolicName>
-                                    <version>${apache.commons.io.version}</version>
+                                    <symbolicName>commons-io</symbolicName>
+                                    <version>${commons.io.version}</version>
                                 </bundle>
                                 <bundle>
                                     <symbolicName>org.yaml.snakeyaml</symbolicName>

--- a/pom.xml
+++ b/pom.xml
@@ -288,9 +288,9 @@
                 <version>${httpclient.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.directory.studio</groupId>
-                <artifactId>org.apache.commons.io</artifactId>
-                <version>${apache.commons.io.version}</version>
+                <groupId>commons-io.wso2</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons.io.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-pool.wso2</groupId>


### PR DESCRIPTION
## Purpose
This PR replaces the outdated `org.apache.directory.studio:org.apache.commons.io` library with commons-io and upgrades the version to `2.11.0.wso2v1`.

Related issue: https://github.com/wso2/api-manager/issues/1236