### PR TITLE
Add diagnostic logs when email sending is handed over to relevant server

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/pom.xml
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/pom.xml
@@ -151,6 +151,7 @@
                 <configuration>
                     <classpathDependencyExcludes>
                         <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/pom.xml
@@ -69,6 +69,14 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -100,6 +108,7 @@
                             org.wso2.carbon.event.output.adapter.email.*
                         </Export-Package>
                         <Import-Package>
+                            org.wso2.carbon.identity.central.log.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             javax.xml.namespace; version=0.0.0,
                             *;resolution:=optional
                         </Import-Package>

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/pom.xml
@@ -104,7 +104,7 @@
                             org.wso2.carbon.event.output.adapter.email.*
                         </Export-Package>
                         <Import-Package>
-                            org.wso2.carbon.identity.central.log.mgt.util; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             javax.xml.namespace; version=0.0.0,
                             *;resolution:=optional
                         </Import-Package>

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/pom.xml
@@ -73,10 +73,6 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.utils</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -108,7 +104,7 @@
                             org.wso2.carbon.event.output.adapter.email.*
                         </Export-Package>
                         <Import-Package>
-                            org.wso2.carbon.identity.central.log.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.util; version="${carbon.identity.framework.imp.pkg.version.range}",
                             javax.xml.namespace; version=0.0.0,
                             *;resolution:=optional
                         </Import-Package>

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
@@ -71,7 +71,6 @@ public class EmailEventAdapter implements OutputEventAdapter {
     private int tenantId;
     private String tenantDomain;
     private String loggableEmail;
-    private boolean isDiagnosticLogsEnabled;
 
     /**
      * Default from address for outgoing messages.
@@ -106,7 +105,6 @@ public class EmailEventAdapter implements OutputEventAdapter {
 
         tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
         tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain(true);
-        isDiagnosticLogsEnabled = LoggerUtils.isDiagnosticLogsEnabled();
 
         //ThreadPoolExecutor will be assigned  if it is null.
         if (threadPoolExecutor == null) {
@@ -373,7 +371,7 @@ public class EmailEventAdapter implements OutputEventAdapter {
                 if (LoggerUtils.isLogMaskingEnable) {
                     loggableEmail = LoggerUtils.getMaskedContent(loggableEmail);
                 }
-                if (isDiagnosticLogsEnabled) {
+                if (LoggerUtils.isDiagnosticLogsEnabled()) {
                     DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
                             EmailEventAdapterConstants.LogConstants.EMAIL_EVENT_ADAPTER_SERVICE,
                             EmailEventAdapterConstants.LogConstants.ActionIDs.HANDOVER_EVENT);

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
@@ -1,21 +1,20 @@
 /*
-*  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*
-*/
+ * Copyright (c) 2015, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.event.output.adapter.email;
 
 import org.apache.axis2.transport.mail.MailConstants;

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/internal/util/EmailEventAdapterConstants.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/internal/util/EmailEventAdapterConstants.java
@@ -66,5 +66,35 @@ public class EmailEventAdapterConstants {
     public static final String MAIL_SMTP_REPLY_TO = "mail.smtp.replyTo";
     public static final String MAIL_SMTP_SIGNATURE = "mail.smtp.signature";
 
+    /**
+     * Define logging constants.
+     */
+    public static class LogConstants {
 
+        private LogConstants() {
+        }
+        public static final String EMAIL_EVENT_ADAPTER_SERVICE = "email-event-adapter-service";
+
+        /**
+         * Define action IDs for diagnostic logs.
+         */
+        public static class ActionIDs {
+
+            private ActionIDs() {
+            }
+
+            public static final String HANDOVER_EVENT = "handover-event";
+        }
+
+        /**
+         * Define common and reusable Input keys for diagnostic logs.
+         */
+        public static class InputKeys {
+
+            private InputKeys() {
+            }
+            public static final String EMAIL_TO = "email to";
+            public static final String TENANT_DOMAIN = "tenant domain";
+        }
+    }
 }

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/internal/util/EmailEventAdapterConstants.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/internal/util/EmailEventAdapterConstants.java
@@ -1,20 +1,20 @@
 /*
-*  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (c) 2015, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.event.output.adapter.email.internal.util;
 
 public class EmailEventAdapterConstants {

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/pom.xml
@@ -101,7 +101,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
-                            org.wso2.carbon.identity.central.log.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.util; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.event.output.adapter.logger.internal,
                             org.wso2.carbon.event.output.adapter.logger.internal.*
                         </Private-Package>

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/pom.xml
@@ -101,7 +101,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
-                            org.wso2.carbon.identity.central.log.mgt.util; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.event.output.adapter.logger.internal,
                             org.wso2.carbon.event.output.adapter.logger.internal.*
                         </Private-Package>

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/pom.xml
@@ -101,7 +101,6 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
-                            org.wso2.carbon.identity.central.log.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.event.output.adapter.logger.internal,
                             org.wso2.carbon.event.output.adapter.logger.internal.*
                         </Private-Package>
@@ -111,6 +110,7 @@
                             org.wso2.carbon.event.output.adapter.logger.*
                         </Export-Package>
                         <Import-Package>
+                            org.wso2.carbon.identity.central.log.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             javax.xml.namespace; version=0.0.0,
                             *;resolution:=optional
                         </Import-Package>

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/pom.xml
@@ -52,6 +52,10 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
@@ -97,6 +101,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
+                            org.wso2.carbon.identity.central.log.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.event.output.adapter.logger.internal,
                             org.wso2.carbon.event.output.adapter.logger.internal.*
                         </Private-Package>

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/pom.xml
@@ -52,10 +52,6 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
@@ -110,7 +106,6 @@
                             org.wso2.carbon.event.output.adapter.logger.*
                         </Export-Package>
                         <Import-Package>
-                            org.wso2.carbon.identity.central.log.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             javax.xml.namespace; version=0.0.0,
                             *;resolution:=optional
                         </Import-Package>

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/src/main/java/org/wso2/carbon/event/output/adapter/sms/SMSEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/src/main/java/org/wso2/carbon/event/output/adapter/sms/SMSEventAdapter.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2015, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/src/main/java/org/wso2/carbon/event/output/adapter/sms/SMSEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/src/main/java/org/wso2/carbon/event/output/adapter/sms/SMSEventAdapter.java
@@ -38,8 +38,6 @@ import org.wso2.carbon.event.output.adapter.core.exception.OutputEventAdapterExc
 import org.wso2.carbon.event.output.adapter.core.exception.TestConnectionNotSupportedException;
 import org.wso2.carbon.event.output.adapter.sms.internal.ds.SMSEventAdapterServiceValueHolder;
 import org.wso2.carbon.event.output.adapter.sms.internal.util.SMSEventAdapterConstants;
-import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
-import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -54,9 +52,6 @@ public final class SMSEventAdapter implements OutputEventAdapter {
     private static ThreadPoolExecutor threadPoolExecutor;
     private Map<String, String> globalProperties;
     private int tenantId;
-    private String tenantDomain;
-    private String loggableSMSNo;
-    private boolean isDiagnosticLogsEnabled;
 
     public SMSEventAdapter(OutputEventAdapterConfiguration eventAdapterConfiguration, Map<String, String> globalProperties) {
         this.eventAdapterConfiguration = eventAdapterConfiguration;
@@ -67,8 +62,6 @@ public final class SMSEventAdapter implements OutputEventAdapter {
     public void init() throws OutputEventAdapterException {
 
         tenantId= PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
-        tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain(true);
-        isDiagnosticLogsEnabled = LoggerUtils.isDiagnosticLogsEnabled();
 
         //ThreadPoolExecutor will be assigned  if it is null
         if (threadPoolExecutor == null) {
@@ -172,32 +165,13 @@ public final class SMSEventAdapter implements OutputEventAdapter {
                 options.setProperty(Constants.Configuration.ENABLE_REST, Constants.VALUE_TRUE);
                 options.setTo(new EndpointReference("sms://" + smsNo));
                 serviceClient.setOptions(options);
-
-                loggableSMSNo = smsNo;
-                if (LoggerUtils.isLogMaskingEnable) {
-                    loggableSMSNo = LoggerUtils.getMaskedContent(loggableSMSNo);
-                }
-                if (isDiagnosticLogsEnabled) {
-                    DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
-                            SMSEventAdapterConstants.LogConstants.SMS_EVENT_ADAPTER_SERVICE,
-                            SMSEventAdapterConstants.LogConstants.ActionIDs.HANDOVER_EVENT);
-                    diagnosticLogBuilder
-                            .inputParam(SMSEventAdapterConstants.LogConstants.InputKeys.TENANT_DOMAIN, tenantDomain)
-                            .inputParam(SMSEventAdapterConstants.LogConstants.InputKeys.EMAIL_TO, loggableSMSNo)
-                            .resultMessage("SMS will be handed over to the SMS server.")
-                            .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
-                            .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION);
-                    LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
-                }
-                log.info(String.format("SMS will be handed over to the SMS server for tenant %s.", tenantDomain));
-
                 serviceClient.fireAndForget(payload);
                 if (log.isDebugEnabled()) {
-                    log.debug("Sending SMS to " + loggableSMSNo + " , message : " + message);
+                    log.debug("Sending SMS to " + smsNo + " , message : " + message);
                 }
             } catch (Exception ex) {
-                EventAdapterUtil.logAndDrop(eventAdapterConfiguration.getName(), message, "Cannot send to '" + loggableSMSNo +
-                        "'", ex, log, tenantId);
+                EventAdapterUtil.logAndDrop(eventAdapterConfiguration.getName(), message, "Cannot send to '"
+                        + smsNo + "'", ex, log, tenantId);
             } finally {
                 if (serviceClient != null) {
                     try {

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/src/main/java/org/wso2/carbon/event/output/adapter/sms/internal/util/SMSEventAdapterConstants.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/src/main/java/org/wso2/carbon/event/output/adapter/sms/internal/util/SMSEventAdapterConstants.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2015, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/src/main/java/org/wso2/carbon/event/output/adapter/sms/internal/util/SMSEventAdapterConstants.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/src/main/java/org/wso2/carbon/event/output/adapter/sms/internal/util/SMSEventAdapterConstants.java
@@ -33,4 +33,36 @@ public final class SMSEventAdapterConstants {
     public static final int MAX_THREAD = 100;
     public static final long DEFAULT_KEEP_ALIVE_TIME = 20;
     public static final String SMS_SEPARATOR =  ",";
+
+    /**
+     * Define logging constants.
+     */
+    public static class LogConstants {
+
+        private LogConstants() {
+        }
+        public static final String SMS_EVENT_ADAPTER_SERVICE = "sms-event-adapter-service";
+
+        /**
+         * Define action IDs for diagnostic logs.
+         */
+        public static class ActionIDs {
+
+            private ActionIDs() {
+            }
+
+            public static final String HANDOVER_EVENT = "handover-event";
+        }
+
+        /**
+         * Define common and reusable Input keys for diagnostic logs.
+         */
+        public static class InputKeys {
+
+            private InputKeys() {
+            }
+            public static final String EMAIL_TO = "sms to";
+            public static final String TENANT_DOMAIN = "tenant domain";
+        }
+    }
 }

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/src/main/java/org/wso2/carbon/event/output/adapter/sms/internal/util/SMSEventAdapterConstants.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.sms/src/main/java/org/wso2/carbon/event/output/adapter/sms/internal/util/SMSEventAdapterConstants.java
@@ -33,36 +33,4 @@ public final class SMSEventAdapterConstants {
     public static final int MAX_THREAD = 100;
     public static final long DEFAULT_KEEP_ALIVE_TIME = 20;
     public static final String SMS_SEPARATOR =  ",";
-
-    /**
-     * Define logging constants.
-     */
-    public static class LogConstants {
-
-        private LogConstants() {
-        }
-        public static final String SMS_EVENT_ADAPTER_SERVICE = "sms-event-adapter-service";
-
-        /**
-         * Define action IDs for diagnostic logs.
-         */
-        public static class ActionIDs {
-
-            private ActionIDs() {
-            }
-
-            public static final String HANDOVER_EVENT = "handover-event";
-        }
-
-        /**
-         * Define common and reusable Input keys for diagnostic logs.
-         */
-        public static class InputKeys {
-
-            private InputKeys() {
-            }
-            public static final String EMAIL_TO = "sms to";
-            public static final String TENANT_DOMAIN = "tenant domain";
-        }
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,14 @@
             </dependency>
             <!--carbon-deployment dependencies stop-->
 
+            <!--carbon-identity-framework dependencies start-->
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <!--carbon-identity-framework dependencies stop-->
+
             <!--siddhi dependencies start-->
             <dependency>
                 <groupId>org.wso2.siddhi</groupId>
@@ -1523,7 +1531,7 @@
         <carbon.analytics.common.version>5.2.55-SNAPSHOT</carbon.analytics.common.version>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.5.3</carbon.kernel.version>
+        <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <!--<carbon.kernel.imp.pkg.version>[4.3.0, 4.4.0)</carbon.kernel.imp.pkg.version>-->
         <securevault.wso2.version>1.1.5</securevault.wso2.version>
@@ -1534,6 +1542,11 @@
 
         <!--CEP versions-->
         <siddhi.version>3.2.9</siddhi.version>
+
+        <!-- Carbon Identity Framework version -->
+        <carbon.identity.framework.version>5.25.328</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 7.0.0)
+        </carbon.identity.framework.imp.pkg.version.range>
 
 
         <orbit.version.json>3.0.0.wso2v2</orbit.version.json>

--- a/pom.xml
+++ b/pom.xml
@@ -1544,7 +1544,7 @@
         <siddhi.version>3.2.9</siddhi.version>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.25.328</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.367</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
> This PR introduces diagnostic logs at the point where email or SMS sending task is handed over to the relevant sending server.

## Related issues
- Issue https://github.com/wso2-enterprise/wso2-iam-internal/issues/769