### PR TITLE
Improve re connection to data endpoints based on configurable values.

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/DataPublisher.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.databridge.agent;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.databridge.agent.conf.AgentConfiguration;
 import org.wso2.carbon.databridge.agent.conf.DataEndpointConfiguration;
 import org.wso2.carbon.databridge.agent.endpoint.DataEndpoint;
 import org.wso2.carbon.databridge.agent.endpoint.DataEndpointGroup;
@@ -174,6 +175,7 @@ public class DataPublisher {
             for (int j = 1; j < receiverGroup.length; j++) {
                 DataEndpointConfiguration endpointConfiguration;
                 String[] urlParams = DataPublisherUtil.getProtocolHostPort((String) receiverGroup[j]);
+                AgentConfiguration agentConfiguration = dataEndpointAgent.getAgentConfiguration();
 
                 if (urlParams[0].equalsIgnoreCase(DataEndpointConfiguration.Protocol.TCP.toString())) {
                     endpointConfiguration = new DataEndpointConfiguration((String) receiverGroup[j],
@@ -184,7 +186,8 @@ public class DataPublisher {
                             dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
                             dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool(),
                             dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds(),
-                            failOver);
+                            failOver, agentConfiguration.getReconnectionInterval(), agentConfiguration.getExpFactor(),
+                            agentConfiguration.getMaxDelayInSeconds());
                 } else {
                     endpointConfiguration = new DataEndpointConfiguration((String) receiverGroup[j],
                             (String) authGroup[j], username, password, dataEndpointAgent.getSecuredTransportPool(),
@@ -194,7 +197,8 @@ public class DataPublisher {
                             dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
                             dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool(),
                             dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds(),
-                            failOver);
+                            failOver,  agentConfiguration.getReconnectionInterval(), agentConfiguration.getExpFactor(),
+                            agentConfiguration.getMaxDelayInSeconds());
                 }
                 DataEndpoint dataEndpoint = dataEndpointAgent.getNewDataEndpoint();
                 dataEndpoint.initialize(endpointConfiguration);

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/AgentConfiguration.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/AgentConfiguration.java
@@ -44,6 +44,8 @@ public class AgentConfiguration {
 
     private int reconnectionInterval;
 
+    private int expFactor;
+    private int maxDelayInSeconds;
     private int queueSize;
 
     private int batchSize;
@@ -139,6 +141,23 @@ public class AgentConfiguration {
         this.reconnectionInterval = reconnectionInterval;
     }
 
+    @XmlElement(name = "ExpFactor")
+    public int getExpFactor() {
+        return expFactor;
+    }
+
+    public void setExpFactor(int expFactor) {
+        this.expFactor = expFactor;
+    }
+
+    @XmlElement(name = "MaxReconnectionInterval")
+    public int getMaxDelayInSeconds() {
+        return maxDelayInSeconds;
+    }
+
+    public void setMaxDelayInSeconds(int maxDelayInSeconds) {
+        this.maxDelayInSeconds = maxDelayInSeconds;
+    }
     @XmlElement(name = "MaxTransportPoolSize")
     public int getMaxTransportPoolSize() {
         return maxTransportPoolSize;

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/DataEndpointConfiguration.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/conf/DataEndpointConfiguration.java
@@ -52,6 +52,28 @@ public class DataEndpointConfiguration {
 
     private boolean failOverEndpoint;
 
+    private int reconnectionInterval;
+
+    private int expFactor;
+
+    private int maxDelayInSeconds;
+
+    public int getReconnectionInterval() {
+        return reconnectionInterval;
+    }
+
+    public int getExpFactor() {
+        return expFactor;
+    }
+
+    public int getMaxDelayInSeconds() {
+        return maxDelayInSeconds;
+    }
+
+    public void setExpFactor(int expFactor) {
+        this.expFactor = expFactor;
+    }
+
     public enum Protocol {
         TCP, SSL;
 
@@ -65,7 +87,8 @@ public class DataEndpointConfiguration {
                                      GenericKeyedObjectPool transportPool,
                                      GenericKeyedObjectPool securedTransportPool,
                                      int batchSize, int corePoolSize, int maxPoolSize, int keepAliveTimeInPool,
-                                     int loggingControlIntervalInSeconds, boolean failOverEndpoint) {
+                                     int loggingControlIntervalInSeconds, boolean failOverEndpoint,
+                                     int reconnectionInterval, int expFactor, int maxDelayInSeconds) {
         this.receiverURL = receiverURL;
         this.authURL = authURL;
         this.username = username;
@@ -80,6 +103,9 @@ public class DataEndpointConfiguration {
         this.keepAliveTimeInPool = keepAliveTimeInPool;
         this.loggingControlIntervalInSeconds = (long) loggingControlIntervalInSeconds;
         this.failOverEndpoint = failOverEndpoint;
+        this.reconnectionInterval = reconnectionInterval;
+        this.expFactor = expFactor;
+        this.maxDelayInSeconds = maxDelayInSeconds;
     }
 
     public String getReceiverURL() {

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.databridge.commons.exception.UndefinedEventTypeException;
 import org.wso2.carbon.databridge.commons.utils.DataBridgeThreadFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -67,6 +68,26 @@ public abstract class DataEndpoint {
     private State state;
 
     private Semaphore immediateDispatchSemaphore;
+
+    public long reConnectTimestamp = 0;
+
+    public static HashMap<String, Long> delayMap=new HashMap<String, Long>();
+
+    public long getReConnectTimestamp() {
+        return reConnectTimestamp;
+    }
+
+    public void setReConnectTimestamp(long reConnectTimestamp) {
+        this.reConnectTimestamp = reConnectTimestamp;
+    }
+
+    public static HashMap<String, Long> getDelayMap() {
+        return delayMap;
+    }
+
+    public static void setDelayMap(HashMap<String, Long> delayMap) {
+        DataEndpoint.delayMap = delayMap;
+    }
 
     public enum State {
         ACTIVE, UNAVAILABLE, BUSY, INITIALIZING
@@ -139,7 +160,7 @@ public abstract class DataEndpoint {
             throws TransportException,
             DataEndpointAuthenticationException, DataEndpointException {
         if (connectionWorker != null) {
-            connectionService.submit(connectionWorker);
+            connectionWorker.runConnection(true);
         } else {
             throw new DataEndpointException("Data Endpoint is not initialized");
         }
@@ -148,7 +169,7 @@ public abstract class DataEndpoint {
     synchronized void syncConnect(String oldSessionId) throws DataEndpointException {
         if (oldSessionId == null || oldSessionId.equalsIgnoreCase(getDataEndpointConfiguration().getSessionId())) {
             if (connectionWorker != null) {
-                connectionWorker.run();
+                connectionWorker.runConnection(false);
             } else {
                 throw new DataEndpointException("Data Endpoint is not initialized");
             }

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpointGroup.java
@@ -62,21 +62,19 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
 
     private EventQueue eventQueue = null;
 
-    private int reconnectionInterval;
-
     private final Integer START_INDEX = 0;
 
     private AtomicInteger currentDataPublisherIndex = new AtomicInteger(START_INDEX);
 
     private AtomicInteger maximumDataPublisherIndex = new AtomicInteger();
 
-    private ScheduledExecutorService reconnectionService;
-
     private final String publishingStrategy;
 
     private boolean isShutdown = false;
 
     private MBeanServer platformMBeanServer;
+
+    private Thread reconnection;
 
     private ObjectName mbeanEventQueue;
 
@@ -87,8 +85,6 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
     public DataEndpointGroup(HAType haType, DataEndpointAgent agent) {
         this.dataEndpoints = new ArrayList<>();
         this.haType = haType;
-        this.reconnectionService = Executors.newScheduledThreadPool(1, new DataBridgeThreadFactory("ReconnectionService"));
-        this.reconnectionInterval = agent.getAgentConfiguration().getReconnectionInterval();
         this.publishingStrategy = agent.getAgentConfiguration().getPublishingStrategy();
         if (!publishingStrategy.equalsIgnoreCase(DataEndpointConstants.SYNC_STRATEGY)) {
             this.eventQueue = new EventQueue(agent.getAgentConfiguration().getQueueSize());
@@ -103,8 +99,9 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
                 log.error("Unable to create DATABRIDGE_AGENT_EVENT_QUEUE stat MXBean: " + e.getMessage(), e);
             }
         }
-        this.reconnectionService.scheduleAtFixedRate(new ReconnectionTask(), reconnectionInterval,
-                reconnectionInterval, TimeUnit.SECONDS);
+        ReconnectionTask reconnectionTask = new ReconnectionTask();
+        reconnection = new Thread(reconnectionTask);
+        reconnection.start();
         currentDataPublisherIndex.set(START_INDEX);
     }
 
@@ -352,7 +349,7 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
                 }
                 if (index == startIndex) {
                     if (isBusyWait) {
-                        if (!reconnectionService.isShutdown()) {
+                        if (reconnection.isAlive()) {
 
                             /**
                              * Have fully iterated the data publisher list,
@@ -436,37 +433,44 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
 
     private class ReconnectionTask implements Runnable {
         public void run() {
-            boolean isOneReceiverConnected = false;
-            List<String> noReceiverURLEndpoints = new ArrayList<String>();
-            for (int i = START_INDEX; i < maximumDataPublisherIndex.get(); i++) {
-                DataEndpoint dataEndpoint = dataEndpoints.get(i);
-                if (!dataEndpoint.isConnected()) {
+            long gap = 0;
+            long isEPCheckedGap = 0;
+            long addedDelayForEPCheck = 10000l;
+            while (true) {
+                for (int i = START_INDEX; i < maximumDataPublisherIndex.get(); i++) {
+                    DataEndpoint dataEndpoint = dataEndpoints.get(i);
                     try {
-                        dataEndpoint.connect();
-                    } catch (Exception ex) {
-                        dataEndpoint.deactivate();
+                        TimeUnit.MILLISECONDS.sleep(10);
+                    } catch (InterruptedException ignored) {
+                        //Exception is ignored as it does not impact the functionality.
                     }
-                } else {
-                    try {
-                        String[] urlElements = DataPublisherUtil.getProtocolHostPort(
-                                dataEndpoint.getDataEndpointConfiguration().getReceiverURL());
-                        if (!isServerExists(urlElements[1], Integer.parseInt(urlElements[2]))) {
+                    if (!dataEndpoint.isConnected()) {
+                        gap = System.currentTimeMillis() - dataEndpoint.getReConnectTimestamp();
+                        try {
+                            if (gap > 0) {
+                                dataEndpoint.connect();
+                            }
+                        } catch (Exception ex) {
                             dataEndpoint.deactivate();
                         }
-                    } catch (DataEndpointConfigurationException exception) {
-                        log.warn("Data Endpoint with receiver URL:" + dataEndpoint.getDataEndpointConfiguration().getReceiverURL()
-                                + " could not be deactivated", exception);
+                    } else {
+                        try {
+                            if (System.currentTimeMillis() > isEPCheckedGap) {
+                                isEPCheckedGap = System.currentTimeMillis() + addedDelayForEPCheck;
+                                String[] urlElements = DataPublisherUtil.getProtocolHostPort(
+                                        dataEndpoint.getDataEndpointConfiguration().getReceiverURL());
+                                if (!isServerExists(urlElements[1], Integer.parseInt(urlElements[2]))) {
+                                    dataEndpoint.deactivate();
+                                }
+                            }
+                        } catch (DataEndpointConfigurationException exception) {
+                            log.warn("Data Endpoint with receiver URL:" +
+                                    dataEndpoint.getDataEndpointConfiguration().getReceiverURL()
+                                    + " could not be deactivated", exception);
+                        }
                     }
                 }
-                if (dataEndpoint.isConnected()) {
-                    isOneReceiverConnected = true;
-                } else {
-                    noReceiverURLEndpoints.add(dataEndpoint.getDataEndpointConfiguration().getReceiverURL());
-                }
-            }
-            if (!isOneReceiverConnected) {
-                log.warn("No receiver is reachable at URL Endpoint/Endpoints " + noReceiverURLEndpoints.toString() +
-                        ", will try to reconnect every " + reconnectionInterval + " sec");
+                busyWait(1);
             }
         }
 
@@ -507,7 +511,7 @@ public class DataEndpointGroup implements DataEndpointFailureCallback {
     }
 
     public void shutdown() {
-        reconnectionService.shutdownNow();
+        reconnection.stop();
         if (eventQueue != null) {
             eventQueue.shutdown();
         }

--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/DataBrigdeWorkerTestCase.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/test/java/org/wso2/carbon/databridge/agent/test/DataBrigdeWorkerTestCase.java
@@ -42,8 +42,8 @@ public class DataBrigdeWorkerTestCase {
 
     @Test
     public void testDataEndpointConnectionWorkerNotInitializedTest() {
-        Thread thread = new Thread(new DataEndpointConnectionWorker());
-        thread.start();
+        DataEndpointConnectionWorker dataEndpointConnectionWorker = new DataEndpointConnectionWorker();
+        dataEndpointConnectionWorker.runConnection(false);
     }
 
     @Test
@@ -66,7 +66,9 @@ public class DataBrigdeWorkerTestCase {
                         dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
                         dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool(),
                         dataEndpointAgent.getAgentConfiguration().getLoggingControlIntervalInSeconds(),
-                        true);
+                        true, dataEndpointAgent.getAgentConfiguration().getReconnectionInterval(),
+                        dataEndpointAgent.getAgentConfiguration().getExpFactor(),
+                        dataEndpointAgent.getAgentConfiguration().getMaxDelayInSeconds());
         DataEndpoint dataEndpoint = dataEndpointAgent.getNewDataEndpoint();
         dataEndpoint.initialize(endpointConfiguration);
         dataEndpointConnectionWorker.initialize(dataEndpoint, endpointConfiguration);

--- a/features/data-bridge/org.wso2.carbon.databridge.agent.server.feature/src/main/resources/conf_templates/templates/repository/conf/data-bridge/data-agent-config.xml.j2
+++ b/features/data-bridge/org.wso2.carbon.databridge.agent.server.feature/src/main/resources/conf_templates/templates/repository/conf/data-bridge/data-agent-config.xml.j2
@@ -48,6 +48,16 @@
         {% if transport.thrift.agent.ciphers is defined %}
         <ciphers>{{transport.thrift.agent.ciphers}}</ciphers>
         {% endif %}
+        {% if transport.thrift.agent.exp_factor is defined %}
+        <ExpFactor>{{transport.thrift.agent.exp_factor}}</ExpFactor>
+        {% else %}
+        <ExpFactor>1</ExpFactor>
+        {% endif %}
+        {% if transport.thrift.agent.max_reconnection_interval is defined %}
+        <MaxReconnectionInterval>{{transport.thrift.agent.max_reconnection_interval}}</MaxReconnectionInterval>
+        {% else %}
+        <MaxReconnectionInterval>3600</MaxReconnectionInterval>
+        {% endif %}
     </Agent>
 
     <Agent>
@@ -79,6 +89,16 @@
         {% endif %}
         {% if transport.binary.agent.ciphers is defined %}
         <ciphers>{{transport.binary.agent.ciphers}}</ciphers>
+        {% endif %}
+        {% if transport.binary.agent.exp_factor is defined %}
+        <ExpFactor>{{transport.binary.agent.exp_factor}}</ExpFactor>
+        {% else %}
+        <ExpFactor>1</ExpFactor>
+        {% endif %}
+        {% if transport.binary.agent.max_reconnection_interval is defined %}
+        <MaxReconnectionInterval>{{transport.binary.agent.max_reconnection_interval}}</MaxReconnectionInterval>
+        {% else %}
+        <MaxReconnectionInterval>3600</MaxReconnectionInterval>
         {% endif %}
     </Agent>
 </DataAgentsConfiguration>


### PR DESCRIPTION
## Purpose
resolves https://github.com/wso2/api-manager/issues/407

Currently the re connection to a failed data endpoints run as a scheduled service with a configurable fixed time gap. This creates lot of logs when a data endpoint goes down in regular interval and create performance impacts while trying to re connect to a endpoint on same fixed intervals. This behavior has been improved to increase the delay between each failed connection attempt exponentially through configurable value to reduce the re connection overhead of a failed endpoint.

Implementation

This is implemented with three configurable properties namely ReConnectionInterval, ExpFacto, MaxReConnectionInterval. The delay between each failed attempt will be increased by ReConnectionInterval * ExpFactor till it reaches the MaxReconnectionInterval. Once it reaches the MaxReconnectionInterval , then every other failed re connection attempts will be executed after the MaxReconnectionInterval. If a connection attempt is succesfull when the data endpoint is running again, then the re connection interval will be re set to its old configured value.

Sample Configurations

[transport.binary.agent]
reconnection_interval = 30
exp_factor=2
max_reconnection_interval = 3600

Sample Behavior with the above configurations

Request attempts

1st failed connection attempt - Adds delay of (30*2) 60 seconds for the next attempt from the current time.

2nd failed connection attempt - Adds delay of (60*2) 120 seconds for the next attempt from the current time.

3rd failed connection attempt - Adds delay of (120*2) 240 secods for the next attempt from the current time.

4th succesffull connection attempt - Resets the delay to its old value and no connection attempt will be made unless the endpoints state changes to UNAVAIABLE.

Note : If someone needs to keep the old behavior to keep retrying in the fixed intervals , then exp_factor factor should be set to 1.