### PR TITLE
[APIM][4.4.0] Handle errors when broker connection is not available

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.jms/src/main/java/org/wso2/carbon/event/output/adapter/jms/internal/util/JMSConnectionFactory.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.jms/src/main/java/org/wso2/carbon/event/output/adapter/jms/internal/util/JMSConnectionFactory.java
@@ -285,9 +285,8 @@ public class JMSConnectionFactory {
         try {
             return (JMSPooledConnectionHolder) this.connectionPool.borrowObject();
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            throw new OutputEventAdapterRuntimeException("Error in getting JMS connection from pool", e);
         }
-        return null;
     }
 
 
@@ -366,10 +365,8 @@ public class JMSConnectionFactory {
                 entry.setProducer(producer);
                 return entry;
             } catch (JMSException e) {
-                log.error(e.getMessage(), e);
-                return null;
+                throw new OutputEventAdapterRuntimeException("Error creating JMS connection holder from JMS CF : " + name, e);
             }
-
         }
 
         @Override


### PR DESCRIPTION
## Purpose
NullPointerException was raised when one or more brokers are not available to connect by getting a connection from the pool.

### Fix
Throw a Runtime Exception when the pooled connection is failed.

- Related issue https://github.com/wso2/api-manager/issues/3125