### PR TITLE
Fix QueueWorker Error in Passing Events Null to Subscribers

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/queue/EventBlockingQueue.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.core/src/main/java/org/wso2/carbon/databridge/core/internal/queue/EventBlockingQueue.java
@@ -81,9 +81,9 @@ public class EventBlockingQueue extends ArrayBlockingQueue<EventComposite> {
     public EventComposite poll() {
         EventComposite eventComposite = super.poll();
         currentSize.addAndGet(-eventComposite.getSize());
-        if (semaphore.availablePermits() == 0 && ((currentEventCompositeSize + currentSize.get()) < maxSize) || isEmpty()) {
+        if (semaphore.availablePermits() == 0 && (((currentEventCompositeSize + currentSize.get()) < maxSize) || isEmpty())) {
             synchronized (lock) {
-                if (semaphore.availablePermits() == 0 && ((currentEventCompositeSize + currentSize.get()) < maxSize) || isEmpty()) {
+                if (semaphore.availablePermits() == 0 && (((currentEventCompositeSize + currentSize.get()) < maxSize) || isEmpty())) {
                     semaphore.release();
                 }
             }


### PR DESCRIPTION
## Purpose
> $subject
> Related to: https://github.com/wso2/api-manager/issues/1319

## Approach
> This issue was caused by an incorrect conditional statement, and the polling comparison logic was restructured to fix it.