### PR TITLE
Avoid client error logging

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/pom.xml
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.axis2.transport</groupId>
             <artifactId>axis2-transport-mail</artifactId>
         </dependency>
@@ -100,6 +104,7 @@
                             org.wso2.carbon.event.output.adapter.email.*
                         </Export-Package>
                         <Import-Package>
+                            org.wso2.carbon.identity.central.log.mgt.utils;version="${carbon.identity.framework.imp.pkg.version.range}",
                             javax.xml.namespace; version=0.0.0,
                             *;resolution:=optional
                         </Import-Package>

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
@@ -1,21 +1,20 @@
 /*
-*  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*
-*/
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.event.output.adapter.email;
 
 import org.apache.axis2.transport.mail.MailConstants;
@@ -31,6 +30,7 @@ import org.wso2.carbon.event.output.adapter.core.exception.ConnectionUnavailable
 import org.wso2.carbon.event.output.adapter.core.exception.OutputEventAdapterException;
 import org.wso2.carbon.event.output.adapter.core.exception.TestConnectionNotSupportedException;
 import org.wso2.carbon.event.output.adapter.email.internal.util.EmailEventAdapterConstants;
+import org.wso2.carbon.event.output.adapter.email.internal.util.EmailEventAdapterUtil;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.utils.DiagnosticLog;
 
@@ -374,7 +374,8 @@ public class EmailEventAdapter implements OutputEventAdapter {
                 }
             } catch (MessagingException e) {
                 LogMessagingException(e, to, 0);
-                EventAdapterUtil.logAndDrop(eventAdapterConfiguration.getName(), message, "Error in message format", e, log, tenantId);
+                EmailEventAdapterUtil.logAndDrop(eventAdapterConfiguration.getName(), message,
+                        "Error in message format", e, log, tenantId);
             } catch (Exception e) {
                 EventAdapterUtil.logAndDrop(eventAdapterConfiguration.getName(), message, "Error sending email to '" + to + "'", e, log, tenantId);
             }
@@ -433,7 +434,9 @@ public class EmailEventAdapter implements OutputEventAdapter {
                     EmailEventAdapterConstants.LogConstants.ActionIDs.HANDLE_EMAIL_SENDING);
             diagnosticLogBuilder
                     .resultMessage(e.getMessage())
-                    .inputParam(EmailEventAdapterConstants.LogConstants.InputKeys.EMAIL_RECIPIENT, mailRecipient)
+                    .inputParam(EmailEventAdapterConstants.LogConstants.InputKeys.EMAIL_RECIPIENT,
+                            LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(mailRecipient) :
+                                    mailRecipient)
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.INTERNAL_SYSTEM)
                     .resultStatus(DiagnosticLog.ResultStatus.FAILED);
             LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.jivesoftware.smack.packet.Authentication;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.event.output.adapter.core.EventAdapterUtil;
 import org.wso2.carbon.event.output.adapter.core.OutputEventAdapter;
@@ -32,6 +31,8 @@ import org.wso2.carbon.event.output.adapter.core.exception.ConnectionUnavailable
 import org.wso2.carbon.event.output.adapter.core.exception.OutputEventAdapterException;
 import org.wso2.carbon.event.output.adapter.core.exception.TestConnectionNotSupportedException;
 import org.wso2.carbon.event.output.adapter.email.internal.util.EmailEventAdapterConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -425,6 +426,19 @@ public class EmailEventAdapter implements OutputEventAdapter {
         } else {
             log.error(errorMessage, e);
         }
+
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    EmailEventAdapterConstants.LogConstants.COMPONENT_ID,
+                    EmailEventAdapterConstants.LogConstants.ActionIDs.HANDLE_EMAIL_SENDING);
+            diagnosticLogBuilder
+                    .resultMessage(e.getMessage())
+                    .inputParam(EmailEventAdapterConstants.LogConstants.InputKeys.EMAIL_RECIPIENT, mailRecipient)
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.INTERNAL_SYSTEM)
+                    .resultStatus(DiagnosticLog.ResultStatus.FAILED);
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        }
+
         // MessagingException has the capability to chain exceptions.
         // Therefore checking for any chained exceptions.
         Exception nextEx = e.getNextException();

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/EmailEventAdapter.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jivesoftware.smack.packet.Authentication;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.event.output.adapter.core.EventAdapterUtil;
 import org.wso2.carbon.event.output.adapter.core.OutputEventAdapter;
@@ -43,6 +44,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import javax.mail.Address;
+import javax.mail.AuthenticationFailedException;
 import javax.mail.Authenticator;
 import javax.mail.Message;
 import javax.mail.MessagingException;
@@ -417,8 +419,12 @@ public class EmailEventAdapter implements OutputEventAdapter {
 
         }
 
-        log.error("Exception occurred when sending email to " + mailRecipient + ". " + e.getMessage(), e);
-
+        String errorMessage = "Exception occurred when sending email to " + mailRecipient + ". " + e.getMessage();
+        if (e instanceof AuthenticationFailedException) {
+            log.warn(errorMessage, e);
+        } else {
+            log.error(errorMessage, e);
+        }
         // MessagingException has the capability to chain exceptions.
         // Therefore checking for any chained exceptions.
         Exception nextEx = e.getNextException();

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/internal/util/EmailEventAdapterConstants.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/internal/util/EmailEventAdapterConstants.java
@@ -66,5 +66,21 @@ public class EmailEventAdapterConstants {
     public static final String MAIL_SMTP_REPLY_TO = "mail.smtp.replyTo";
     public static final String MAIL_SMTP_SIGNATURE = "mail.smtp.signature";
 
+    /**
+     * Constants related to logging.
+     */
+    public static class LogConstants {
 
+        public static final String COMPONENT_ID = "event-output-adapter-email";
+
+        public static class ActionIDs {
+
+            public static final String HANDLE_EMAIL_SENDING = "handle-email-sending";
+        }
+
+        public static class InputKeys {
+
+            public static final String EMAIL_RECIPIENT = "email recipient";
+        }
+    }
 }

--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/internal/util/EmailEventAdapterUtil.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.email/src/main/java/org/wso2/carbon/event/output/adapter/email/internal/util/EmailEventAdapterUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.event.output.adapter.email.internal.util;
+
+import org.apache.commons.logging.Log;
+
+import javax.mail.AuthenticationFailedException;
+
+public class EmailEventAdapterUtil {
+
+    private EmailEventAdapterUtil() {
+
+    }
+
+    public static void logAndDrop(String adapterName, Object event, String message, Throwable e, Log log,
+                                  int tenantId) {
+
+        if (message != null) {
+            message = message + ", ";
+        } else {
+            message = "";
+        }
+        String errorMessage = "Event dropped at Output Adapter '" + adapterName + "' for tenant id '" +
+                tenantId + "', " + message + e.getMessage();
+        if (e instanceof AuthenticationFailedException) {
+            log.warn(errorMessage, e);
+        } else {
+            log.error(errorMessage, e);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    "Error at Output Adapter '" + adapterName + "' for tenant id '" + tenantId + "', dropping event: \n"
+                            + event, e);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,11 @@
                 <artifactId>org.wso2.carbon.identity.authentication</artifactId>
                 <version>${carbon.commons.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
             <!--carbon-commons dependencies stop-->
 
             <!--carbon-deployment dependencies start-->
@@ -1523,9 +1528,13 @@
         <carbon.analytics.common.version>5.2.60-SNAPSHOT</carbon.analytics.common.version>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.5.3</carbon.kernel.version>
+        <carbon.kernel.version>4.10.24</carbon.kernel.version>
         <carbon.kernel.feature.version>${carbon.kernel.version}</carbon.kernel.feature.version>
         <!--<carbon.kernel.imp.pkg.version>[4.3.0, 4.4.0)</carbon.kernel.imp.pkg.version>-->
+        <!-- Carbon Identity Framework version -->
+        <carbon.identity.framework.version>7.6.15</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
+        </carbon.identity.framework.imp.pkg.version.range>
         <securevault.wso2.version>1.1.5</securevault.wso2.version>
 
         <carbon.commons.version>4.7.19</carbon.commons.version>


### PR DESCRIPTION
## Purpose
> This PR is for avoiding logging client errors as server errors when sending emails. Client errors and transient errors like connection being lost are encapsulated within `javax.mail.AuthenticationFailedException` instance. W can warn log if the exception is of this type, and continue to error log otherwise, since we need to error log all server errors.

## Related issues
- https://github.com/wso2/product-is/issues/21777