### PR TITLE
Introduce a ThreadPool to the EventJunction to Publish Events in Parallel

### DIFF
--- a/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.jms/src/main/java/org/wso2/carbon/event/output/adapter/jms/JMSEventAdapter.java
+++ b/components/event-publisher/event-output-adapters/org.wso2.carbon.event.output.adapter.jms/src/main/java/org/wso2/carbon/event/output/adapter/jms/JMSEventAdapter.java
@@ -45,7 +45,7 @@ public class JMSEventAdapter implements OutputEventAdapter {
     private OutputEventAdapterConfiguration eventAdapterConfiguration;
     private Map<String, String> globalProperties;
     private PublisherDetails publisherDetails = null;
-    private static ExecutorService executorService;
+    private ExecutorService executorService;
     private int tenantId;
 
     public JMSEventAdapter(OutputEventAdapterConfiguration eventAdapterConfiguration,

--- a/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/EventConsumerThread.java
+++ b/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/EventConsumerThread.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.event.stream.core.internal;
+
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.databridge.commons.Event;
+import org.wso2.carbon.event.stream.core.WSO2EventConsumer;
+
+/**
+ * This class is used to consume events from the event stream.
+ */
+public class EventConsumerThread implements Runnable {
+    private WSO2EventConsumer consumer;
+    private Event event;
+    private int tenantId;
+
+    public EventConsumerThread(WSO2EventConsumer consumer, Event event, int tenantId) {
+        this.consumer = consumer;
+        this.event = event;
+        this.tenantId = tenantId;
+    }
+
+    @Override
+    public void run() {
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(tenantId);
+        consumer.onEvent(event);
+    }
+}

--- a/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/config/EventPublisherConfigs.java
+++ b/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/config/EventPublisherConfigs.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.wso2.carbon.event.stream.core.internal.config;
+
+import org.wso2.carbon.event.stream.core.internal.util.EventStreamConstants;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * AdapterConfigs class is used to represent the configuration of the output event adapters.
+ */
+@XmlRootElement(name="outputEventAdaptersConfig")
+public class EventPublisherConfigs {
+
+    private int minThread;
+    private int maxThread;
+    private int keepAliveTime;
+    private int jobQueueSize;
+
+    @XmlElement(name="minThread")
+    public void setMinThread(int minThread) {
+        this.minThread = minThread;
+    }
+
+    @XmlElement(name="maxThread")
+    public void setMaxThread(int maxThread) {
+        this.maxThread = maxThread;
+    }
+
+    @XmlElement(name="keepAliveTime")
+    public void setKeepAliveTime(int keepAliveTime) {
+        this.keepAliveTime = keepAliveTime;
+    }
+
+    @XmlElement(name="jobQueueSize")
+    public void setJobQueueSize(int jobQueueSize) {
+        this.jobQueueSize = jobQueueSize;
+    }
+
+    public Map<String, Integer> getEventPublisherThreadPoolConfigs() {
+        Map<String, Integer> eventPublisherConfigs = new HashMap<>();
+        eventPublisherConfigs.put(EventStreamConstants.EVENT_PUBLISHER_MIN_THREAD_POOL_SIZE, minThread);
+        eventPublisherConfigs.put(EventStreamConstants.EVENT_PUBLISHER_MAX_THREAD_POOL_SIZE, maxThread);
+        eventPublisherConfigs.put(EventStreamConstants.EVENT_PUBLISHER_KEEP_ALIVE_TIME, keepAliveTime);
+        eventPublisherConfigs.put(EventStreamConstants.EVENT_PUBLISHER_JOB_QUEUE_SIZE, jobQueueSize);
+        return eventPublisherConfigs;
+    }
+}

--- a/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/ds/EventStreamServiceDS.java
+++ b/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/ds/EventStreamServiceDS.java
@@ -26,6 +26,8 @@ import org.wso2.carbon.event.stream.core.EventStreamListener;
 import org.wso2.carbon.event.stream.core.EventStreamService;
 import org.wso2.carbon.event.stream.core.internal.CarbonEventStreamService;
 import org.wso2.carbon.event.stream.core.internal.EventStreamRuntime;
+import org.wso2.carbon.event.stream.core.internal.util.EventPublisherConfigHelper;
+import org.wso2.carbon.securevault.SecretCallbackHandlerService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
 @Component(
@@ -39,6 +41,7 @@ public class EventStreamServiceDS {
     protected void activate(ComponentContext context) {
 
         try {
+            EventStreamServiceValueHolder.setEventPublisherConfigs(EventPublisherConfigHelper.loadGlobalConfigs());
             EventStreamServiceValueHolder.registerEventStreamRuntime(new EventStreamRuntime());
             CarbonEventStreamService carbonEventStreamService = new CarbonEventStreamService();
             EventStreamServiceValueHolder.setCarbonEventStreamService(carbonEventStreamService);
@@ -85,5 +88,21 @@ public class EventStreamServiceDS {
     protected void unsetEventStreamListener(EventStreamListener eventStreamListener) {
 
         EventStreamServiceValueHolder.unregisterEventStreamListener(eventStreamListener);
+    }
+
+    @Reference(
+            name = "secret.callback.handler.service",
+            service = org.wso2.carbon.securevault.SecretCallbackHandlerService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetSecretCallbackHandlerService")
+    protected void setSecretCallbackHandlerService(SecretCallbackHandlerService secretCallbackHandlerService) {
+
+        EventStreamServiceValueHolder.setSecretCallbackHandlerService(secretCallbackHandlerService);
+    }
+
+    protected void unsetSecretCallbackHandlerService(SecretCallbackHandlerService secretCallbackHandlerService) {
+
+        EventStreamServiceValueHolder.setSecretCallbackHandlerService(null);
     }
 }

--- a/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/ds/EventStreamServiceValueHolder.java
+++ b/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/ds/EventStreamServiceValueHolder.java
@@ -17,6 +17,8 @@ package org.wso2.carbon.event.stream.core.internal.ds;
 import org.wso2.carbon.event.stream.core.EventStreamListener;
 import org.wso2.carbon.event.stream.core.internal.CarbonEventStreamService;
 import org.wso2.carbon.event.stream.core.internal.EventStreamRuntime;
+import org.wso2.carbon.event.stream.core.internal.config.EventPublisherConfigs;
+import org.wso2.carbon.securevault.SecretCallbackHandlerService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
 import java.util.List;
@@ -28,6 +30,8 @@ public class EventStreamServiceValueHolder {
     private static ConfigurationContextService configurationContextService;
     private static List<EventStreamListener> eventStreamListenerList =  new CopyOnWriteArrayList<EventStreamListener>();
     private static EventStreamRuntime eventStreamRuntime;
+    private static EventPublisherConfigs eventPublisherConfigs;
+    private static SecretCallbackHandlerService secretCallbackHandlerService;
 
     private EventStreamServiceValueHolder() {
 
@@ -68,5 +72,21 @@ public class EventStreamServiceValueHolder {
 
     public static void registerEventStreamRuntime(EventStreamRuntime eventStreamRuntime) {
         EventStreamServiceValueHolder.eventStreamRuntime = eventStreamRuntime;
+    }
+
+    public static void setEventPublisherConfigs(EventPublisherConfigs globalAdapterConfigs) {
+        EventStreamServiceValueHolder.eventPublisherConfigs = globalAdapterConfigs;
+    }
+
+    public static EventPublisherConfigs getEventPublisherConfigs() {
+        return eventPublisherConfigs;
+    }
+
+    public static void setSecretCallbackHandlerService(SecretCallbackHandlerService secretCallbackHandlerService) {
+        EventStreamServiceValueHolder.secretCallbackHandlerService = secretCallbackHandlerService;
+    }
+
+    public static SecretCallbackHandlerService getSecretCallbackHandlerService() {
+        return secretCallbackHandlerService;
     }
 }

--- a/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/util/EventPublisherConfigHelper.java
+++ b/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/util/EventPublisherConfigHelper.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.event.stream.core.internal.util;
+
+import org.apache.axiom.om.OMAttribute;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.core.util.CryptoException;
+import org.wso2.carbon.event.stream.core.exception.EventStreamConfigurationException;
+import org.wso2.carbon.event.stream.core.internal.config.EventPublisherConfigs;
+import org.wso2.carbon.event.stream.core.internal.ds.EventStreamServiceValueHolder;
+import org.wso2.carbon.utils.CarbonUtils;
+import org.wso2.securevault.SecretResolver;
+import org.wso2.securevault.SecretResolverFactory;
+import org.wso2.securevault.commons.MiscellaneousUtil;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.namespace.QName;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Iterator;
+
+/**
+ * This class is used to load the global output event adapter configurations from the output-event-adapters.xml file.
+ */
+public class EventPublisherConfigHelper {
+
+    private static final Log log = LogFactory.getLog(EventPublisherConfigHelper.class);
+    private static SecretResolver secretResolver;
+
+    public static void secureResolveOmElement(OMElement doc) throws EventStreamConfigurationException {
+
+        if (doc != null) {
+            try {
+                secretResolver = SecretResolverFactory.create(doc, true);
+                secureLoadOMElement(doc);
+            } catch (CryptoException e) {
+                throw new EventStreamConfigurationException("Error in secure load of global output event adapter properties: " +
+                        e.getMessage(), e);
+            }
+        }
+    }
+
+    private static void secureLoadOMElement(OMElement element) throws CryptoException {
+
+        String alias = MiscellaneousUtil.getProtectedToken(element.getText());
+        if (alias != null && !alias.isEmpty()) {
+            element.setText(loadFromSecureVault(alias));
+        } else {
+            OMAttribute secureAttr = element.getAttribute(new QName(EventStreamConstants.SECURE_VAULT_NS,
+                    EventStreamConstants.SECRET_ALIAS_ATTR_NAME));
+            if (secureAttr != null) {
+                element.setText(loadFromSecureVault(secureAttr.getAttributeValue()));
+                element.removeAttribute(secureAttr);
+            }
+        }
+        Iterator<OMElement> childNodes = element.getChildElements();
+        while (childNodes.hasNext()) {
+            OMElement tmpNode = childNodes.next();
+            secureLoadOMElement(tmpNode);
+        }
+    }
+
+    public static OMElement convertToOmElement(File file) throws EventStreamConfigurationException {
+
+        try {
+            StAXOMBuilder builder = new StAXOMBuilder(new FileInputStream(file));
+            return builder.getDocumentElement();
+        } catch (Exception e) {
+            throw new EventStreamConfigurationException("Error in creating an XML document from file: " +
+                    e.getMessage(), e);
+        }
+    }
+
+    private static synchronized String loadFromSecureVault(String alias) {
+        if (secretResolver == null) {
+            secretResolver = SecretResolverFactory.create((OMElement) null, false);
+            secretResolver.init(EventStreamServiceValueHolder.
+                    getSecretCallbackHandlerService().getSecretCallbackHandler());
+        }
+        return secretResolver.resolve(alias);
+    }
+
+    public static EventPublisherConfigs loadGlobalConfigs() {
+
+        String path = CarbonUtils.getCarbonConfigDirPath() + File.separator + EventStreamConstants.GLOBAL_CONFIG_FILE_NAME;
+        try {
+            JAXBContext jaxbContext = JAXBContext.newInstance(EventPublisherConfigs.class);
+            Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+
+            File configFile = new File(path);
+            if (!configFile.exists()) {
+                log.warn(EventStreamConstants.GLOBAL_CONFIG_FILE_NAME + " can not found in " + path + "," +
+                        " hence Output Event Adapters will be running with default global configs.");
+            }
+            OMElement globalConfigDoc = convertToOmElement(configFile);
+            secureResolveOmElement(globalConfigDoc);
+            return (EventPublisherConfigs) unmarshaller.unmarshal(globalConfigDoc.getXMLStreamReader());
+        } catch (JAXBException e) {
+            log.error("Error in loading " + EventStreamConstants.GLOBAL_CONFIG_FILE_NAME + " from " + path + "," +
+                    " hence Output Event Adapters will be running with default global configs.");
+        } catch (EventStreamConfigurationException e) {
+            log.error("Error in loading " + EventStreamConstants.GLOBAL_CONFIG_FILE_NAME + " from " + path + "," +
+                    " hence Output Event Adapters will be running with default global configs.");
+        }
+        return new EventPublisherConfigs();
+    }
+}

--- a/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/util/EventStreamConstants.java
+++ b/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/util/EventStreamConstants.java
@@ -62,5 +62,13 @@ public interface EventStreamConstants {
     public static final String EVENT_ATTRIBUTE_VALUE_SEPARATOR = ":";
     public static final String EVENT_ATTRIBUTE_SEPARATOR = ",";
 
+    public static final String GLOBAL_CONFIG_FILE_NAME = "output-event-adapters.xml";
+    public static final String SECURE_VAULT_NS = "http://org.wso2.securevault/configuration";
+    public static final String SECRET_ALIAS_ATTR_NAME = "secretAlias";
+
+    public static final String EVENT_PUBLISHER_MIN_THREAD_POOL_SIZE = "minThread";
+    public static final String EVENT_PUBLISHER_MAX_THREAD_POOL_SIZE = "maxThread";
+    public static final String EVENT_PUBLISHER_KEEP_ALIVE_TIME = "keepAliveTime";
+    public static final String EVENT_PUBLISHER_JOB_QUEUE_SIZE = "jobQueueSize";
 
 }

--- a/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/org.wso2.carbon.event.output.adapter.default.json
+++ b/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/org.wso2.carbon.event.output.adapter.default.json
@@ -16,5 +16,9 @@
   "output_adapter.email.enable_authentication": true,
   "output_adapter.email.signature": "$ref{output_adapter.email.username}",
   "output_adapter.email.reply_to": "$ref{output_adapter.email.from_address}",
-  "output_adapter.http.enable_form_url_encoded": false
+  "output_adapter.http.enable_form_url_encoded": false,
+  "output_adapter.publisher.min_thread": "100",
+  "output_adapter.publisher.max_thread": "150",
+  "output_adapter.publisher.keep_alive_time": "20000",
+  "output_adapter.publisher.job_queue_size": "100"
 }

--- a/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/templates/repository/conf/output-event-adapters.xml.j2
+++ b/features/event-publisher/org.wso2.carbon.event.output.adapter.server.feature/src/main/resources/conf_templates/templates/repository/conf/output-event-adapters.xml.j2
@@ -15,6 +15,12 @@
 
 <outputEventAdaptersConfig xmlns:svns="http://org.wso2.securevault/configuration">
 
+    <!-- Publisher Thread Pool Related Properties -->
+    <minThread key="minThread">{{output_adapter.publisher.min_thread}}</minThread>
+    <maxThread key="maxThread">{{output_adapter.publisher.max_thread}}</maxThread>
+    <keepAliveTime key="keepAliveTime">{{output_adapter.publisher.keep_alive_time}}</keepAliveTime>
+    <jobQueueSize key="jobQueueSize">{{output_adapter.publisher.job_queue_size}}</jobQueueSize>
+
     <adapterConfig type="wso2event">
         <property key="default.thrift.tcp.url">tcp://localhost:7612</property>
         <property key="default.thrift.ssl.url">ssl://localhost:7712</property>


### PR DESCRIPTION
### Description
This PR introduces a thread pool to the EventJunction component to enable parallel event publishing. The enhancement improves performance under high event loads.

### Related issues
- https://github.com/wso2/api-manager/issues/3125
- https://github.com/wso2/api-manager/issues/3183

### Fix
- Make `executorService` non-static in the `JMSEventAdapter`
- Introduce a ThreadPool to publish events to `wso2EventConsumers`
