### PR TITLE
Upgrade json-smart version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1560,7 +1560,7 @@
         <!--<httpclient.wso2.version>4.2.5.wso2v1</httpclient.wso2.version>-->
         <jsonpath.version>2.9.0.wso2v1</jsonpath.version>
         <jayway.jsonpath.orbit.version>2.9.0.wso2v1</jayway.jsonpath.orbit.version>
-        <jsonsmart.version>2.5.0</jsonsmart.version>
+        <jsonsmart.version>2.5.2</jsonsmart.version>
         <javax.websocket.version>1.0</javax.websocket.version>
         <jaggery.version>0.12.8</jaggery.version>
         <testng.version>6.11</testng.version>


### PR DESCRIPTION
### Purpose
To upgrade json-smart version from 2.5.0 to the non-vulnerable 2.5.2 version.

#### Related PRs:

Identity-inbound-auth-oauth: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2730
Carbon-identity-framework: https://github.com/wso2/carbon-identity-framework/pull/6543
Identity-inbound-auth-openid: https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/109
Identity-outbound-auth-oidc: https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/199
Carbon-mediation: https://github.com/wso2/carbon-mediation/pull/1767
Carbon-apimgt: https://github.com/wso2/carbon-apimgt/pull/12953
Product-apim: https://github.com/wso2/product-apim/pull/13688