### PR TITLE
Escape user given xml input field to prevent xss

### DIFF
--- a/components/event-publisher/org.wso2.carbon.event.publisher.ui/src/main/resources/web/eventpublisher/eventPublisher_details.jsp
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.ui/src/main/resources/web/eventpublisher/eventPublisher_details.jsp
@@ -13,6 +13,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   --%>
+<%@ page import="org.apache.taglibs.standard.functions.Functions" %>
 <%@ page
         import="org.wso2.carbon.event.publisher.stub.EventPublisherAdminServiceStub" %>
 
@@ -363,7 +364,7 @@
                    name="<%=eventPublisherPropertyDto[index].getKey()%>"
                    id="<%=propertyId%><%=index%>" class="initE"
                    style="width:75%"
-                   value="<%= eventPublisherPropertyDto[index].getValue() != null ? eventPublisherPropertyDto[index].getValue() : "" %>" disabled="disabled"/>
+                   value="<%= eventPublisherPropertyDto[index].getValue() != null ? Functions.escapeXml(eventPublisherPropertyDto[index].getValue()) : "" %>" disabled="disabled"/>
 
             <% } %>
 
@@ -443,7 +444,7 @@
                    name="<%=eventPublisherPropertyDto[index].getKey()%>"
                    id="<%=propertyId%><%=index%>" class="initE"
                    style="width:75%"
-                   value="<%= eventPublisherPropertyDto[index].getValue() != null ? eventPublisherPropertyDto[index].getValue() : "" %>" disabled="disabled"/>
+                   value="<%= eventPublisherPropertyDto[index].getValue() != null ? Functions.escapeXml(eventPublisherPropertyDto[index].getValue()) : "" %>" disabled="disabled"/>
 
             <% } %>
 

--- a/components/event-receiver/org.wso2.carbon.event.receiver.ui/src/main/resources/web/eventreceiver/eventReceiver_details.jsp
+++ b/components/event-receiver/org.wso2.carbon.event.receiver.ui/src/main/resources/web/eventreceiver/eventReceiver_details.jsp
@@ -13,6 +13,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   --%>
+<%@ page import="org.apache.taglibs.standard.functions.Functions" %>
 <%@ page
         import="org.wso2.carbon.event.receiver.stub.EventReceiverAdminServiceStub" %>
 
@@ -324,7 +325,7 @@
                    name="<%=eventReceiverPropertyDto[index].getKey()%>"
                    id="<%=propertyId%><%=index%>" class="initE"
                    style="width:75%"
-                   value="<%= eventReceiverPropertyDto[index].getValue() != null ? eventReceiverPropertyDto[index].getValue() : "" %>" disabled="disabled"/>
+                   value="<%= eventReceiverPropertyDto[index].getValue() != null ? Functions.escapeXml(eventReceiverPropertyDto[index].getValue()) : "" %>" disabled="disabled"/>
 
             <% } %>
 


### PR DESCRIPTION
## Purpose
This pull request addresses an XSS vulnerability in the input fields of the Management Console's Event Listener and Publisher pages. The fields were not properly escaped, posing a potential security risk [1].

## Implmentation
The fix ensures proper escaping of user-provided input using the `org.apache.taglibs.standard.functions.Functions.escapeXml` method [2].

## References
[1] - https://security-advisory.wso2.com/dashboard/advisory?name=WSO2-2025-4316
[2] - https://tomcat.apache.org/taglibs/standard/apidocs/org/apache/taglibs/standard/functions/Functions.html#escapeXml(java.lang.String)