### PR TITLE
Improve high frequent connection logins over the error 'broken-pipe' …

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/DataEndpoint.java
@@ -350,16 +350,14 @@ public abstract class DataEndpoint {
         }
 
         private void publish() throws DataEndpointException, SessionTimeoutException, UndefinedEventTypeException {
-            Object client = getClient();
             if (invalidateTransportPool) {
-                log.debug(
-                        "invalidateTransportPool' is 'true'. Going to discard existing client and get new client " +
-                                "for the DataEndpoint");
-                discardClient(client);
-                client = getClient();
+                transportPool.clear(getDataEndpointConfiguration().getPublisherKey());
+                log.debug("invalidateTransportPool' is 'true'. Discarding clients for the DataEndpoint: " +
+                        getDataEndpointConfiguration().getPublisherKey());
                 invalidateTransportPool = false;
                 log.debug("'invalidateTransportPool' is set to 'false' for the DataEndpoint");
             }
+            Object client = getClient();
             try {
                 send(client, this.events);
                 semaphoreRelease();


### PR DESCRIPTION
## Purpose

The previous fix implemented in [1] closed only a single socket, not the entire pool. This PR enhances the fix by closing the entire pool to better handle high-frequency connection logins and reduce 'broken-pipe' errors in binary transport.

[1] - https://github.com/wso2/carbon-analytics-common/pull/847

## Issue
https://github.com/wso2/api-manager/issues/3404
