### PR TITLE
Update log4j version from 2.12.0|2.17.1 to 2.24.3

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/pom.xml
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/pom.xml
@@ -99,19 +99,19 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
+            <version>2.24.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
+            <version>2.24.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.1</version>
+            <version>2.24.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1236,12 +1236,12 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.12.0</version>
+                <version>2.24.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>2.12.0</version>
+                <version>2.24.3</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>


### PR DESCRIPTION
This PR updates the Log4j library to the latest stable version to improve security, performance, and compatibility.

### Changes Made

**Logging Libraries:**
- **log4j**: `2.12.0` / `2.17.1` → `2.24.3`

Related Issue: https://github.com/wso2/api-manager/issues/3870