### PR TITLE
Bump jackson → 2.21/2.21.2, snakeyaml → 2.6, commons-lang3 → 3.20.0, msf4j → 2.8.14-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -527,7 +527,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${com.fasterxml.jackson.core.version}</version>
+                <version>${com.fasterxml.jackson.annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>
@@ -792,8 +792,8 @@
         </equinox.simpleconfigurator.manipulator.version>
         <equinox.util.version>1.0.500.v20130404-1337</equinox.util.version>
         <org.eclipse.equinox.cm.version>1.1.0.v20131021-1936</org.eclipse.equinox.cm.version>
-        <org.snakeyaml.version>2.2</org.snakeyaml.version>
-        <org.snakeyaml.bundle.version>2.2.0</org.snakeyaml.bundle.version>
+        <org.snakeyaml.version>2.6</org.snakeyaml.version>
+        <org.snakeyaml.bundle.version>2.6.0</org.snakeyaml.bundle.version>
         <org.wso2.eclipse.osgi.version>3.4.0.v20140312-2051</org.wso2.eclipse.osgi.version>
 
         <!-- Maven plugins -->
@@ -861,11 +861,12 @@
         <carbon.messaging.version>3.0.3</carbon.messaging.version>
         <carbon.messaging.package.import.version.range>[0.0.0, 4.0.0)</carbon.messaging.package.import.version.range>
 
-        <msf4j.version>2.8.7</msf4j.version>
+        <msf4j.version>2.8.14-SNAPSHOT</msf4j.version>
         <msf4j.import.version.range>[2.5.0, 3.0.0)</msf4j.import.version.range>
 
-        <com.fasterxml.jackson.core.version>2.18.6</com.fasterxml.jackson.core.version>
-        <com.fasterxml.jackson.databind.version>2.18.6</com.fasterxml.jackson.databind.version>
+        <com.fasterxml.jackson.annotations.version>2.21</com.fasterxml.jackson.annotations.version>
+        <com.fasterxml.jackson.core.version>2.21.2</com.fasterxml.jackson.core.version>
+        <com.fasterxml.jackson.databind.version>2.21.2</com.fasterxml.jackson.databind.version>
         <io.swagger.version>1.6.9</io.swagger.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <javax.ws.rs.version.range>[2.0.0, 3.0.0)</javax.ws.rs.version.range>
@@ -873,7 +874,7 @@
         <javax.websocket.version.range>[1.1.0, 2.0.0)</javax.websocket.version.range>
         <org.snakeyaml.import.version.range>[1.17.0,3.0.0)</org.snakeyaml.import.version.range>
         <awaitility.version>3.1.6</awaitility.version>
-        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
 
         <carbon.touchpoint.version>1.1.1</carbon.touchpoint.version>
         <carbon.utils.version>2.1.1</carbon.utils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -773,7 +773,7 @@
         <wso2.slf4j.version>1.5.10.wso2v1</wso2.slf4j.version>
         <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>
 
-        <pax.logging.log4j2.version>2.2.9-wso2v2</pax.logging.log4j2.version>
+        <pax.logging.log4j2.version>2.2.9-wso2v3</pax.logging.log4j2.version>
         <apache.felix.gogo.command.version>0.10.0.v201209301215</apache.felix.gogo.command.version>
         <apache.felix.gogo.runtime.version>0.10.0.v201209301036</apache.felix.gogo.runtime.version>
         <apache.felix.gogo.shell.version>0.10.0.v201212101605</apache.felix.gogo.shell.version>
@@ -861,7 +861,7 @@
         <carbon.messaging.version>3.0.3</carbon.messaging.version>
         <carbon.messaging.package.import.version.range>[0.0.0, 4.0.0)</carbon.messaging.package.import.version.range>
 
-        <msf4j.version>2.8.14-SNAPSHOT</msf4j.version>
+        <msf4j.version>2.9.0</msf4j.version>
         <msf4j.import.version.range>[2.5.0, 3.0.0)</msf4j.import.version.range>
 
         <com.fasterxml.jackson.annotations.version>2.21</com.fasterxml.jackson.annotations.version>


### PR DESCRIPTION
**NOTE - Bump msf4j version after msf4j release**

## Summary

- **jackson-annotations**: 2.18.6 → 2.21 (split into dedicated property; 2.21.2 does not exist for annotations artifact)
- **jackson-core / jackson-databind / jackson-datatype-joda / jackson-jaxrs-json-provider**: 2.18.6 → 2.21.2 (fixes CVE-2025-52999 & GHSA-72hv)
- **snakeyaml**: 2.2 → 2.6 (bundle version: 2.2.0 → 2.6.0)
- **commons-lang3**: 3.17.0 → 3.20.0 (fixes CVE-2025-48924, fixed in 3.18.0)
- **msf4j**: 2.8.7 → 2.8.14-SNAPSHOT

Part of the SI 4.3.2 release dependency bump cycle.

## Test plan

- [x] `mvn clean install -DskipTests` passes with Java 11 (all 30 modules SUCCESS)
- [ ] OSGi integration tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)