### PR TITLE
Revert invalid log statements in ThriftClientPoolFactory

### DIFF
--- a/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/thrift/ThriftClientPoolFactory.java
+++ b/components/data-bridge/org.wso2.carbon.databridge.agent/src/main/java/org/wso2/carbon/databridge/agent/endpoint/thrift/ThriftClientPoolFactory.java
@@ -46,12 +46,9 @@ public class ThriftClientPoolFactory extends AbstractClientPoolFactory {
             ThriftEventTransmissionService.Client client;
             try {
                 TTransport receiverTransport = new TSocket(new TConfiguration(), hostName, port, socketTimeout);
-                log.info("Creating Thrift client connection to " + hostName + ":" + port);
                 TProtocol tProtocol = new TBinaryProtocol(receiverTransport);
                 client = new ThriftEventTransmissionService.Client(tProtocol);
                 receiverTransport.open();
-                log.debug("Successfully opened Thrift transport connection to " + hostName + ":" + port);
-                return client;
             } catch (TTransportException e) {
                 throw new DataEndpointException("Error while making the connection." + e.getMessage(), e);
             }


### PR DESCRIPTION
## Summary
- Removes three lines added by the bot-applied "Apply suggestions from code review" commit (`d46a2ff444`) in PR #920 that referenced a non-existent `log` variable in `ThriftClientPoolFactory`.
- The Jenkins build for #920 (commit `967d627c04`) failed with `cannot find symbol: variable log` at lines 49 and 53 of `ThriftClientPoolFactory.java` because the class has no logger field and no logger import. The patch also added a redundant early `return client;` inside the try block, leaving the post-`try/catch` return unreachable.
- This restores the `createClient(...)` body to the original from `a379744dac` (the libthrift 0.23.0.wso2v1 bump) so the module compiles cleanly.

## Test plan
- [ ] Module `org.wso2.carbon.databridge.agent` compiles without `cannot find symbol` errors
- [ ] Full reactor build (`mvn clean install`) reaches `BUILD SUCCESS`
- [ ] Jenkins build succeeds; next release (`v6.1.75`) picks up the libthrift bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)