### PR TITLE
Add APIs to remove a tenant's event publisher and stream state from memory

### DIFF
--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/EventPublisherService.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/EventPublisherService.java
@@ -245,4 +245,16 @@ public interface EventPublisherService {
 
     }
 
+    /**
+     * Removes every event publisher configuration and its runtime artifacts (output adapter instances,
+     * event stream subscriptions) held in memory for the given tenant. Intended to be invoked when a
+     * tenant is unloaded, so that per-tenant publisher state does not accumulate for every tenant ever
+     * loaded during the server's lifetime. Must be invoked within the tenant's carbon context flow.
+     *
+     * @param tenantId Tenant ID.
+     */
+    public default void removeEventPublisherConfigurations(int tenantId) {
+
+    }
+
 }

--- a/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/CarbonEventPublisherService.java
+++ b/components/event-publisher/org.wso2.carbon.event.publisher.core/src/main/java/org/wso2/carbon/event/publisher/core/internal/CarbonEventPublisherService.java
@@ -395,6 +395,30 @@ public class CarbonEventPublisherService implements EventPublisherService {
         tenantSpecificEventPublisherConfigurationMap.put(tenantId, eventPublisherConfigurationMap);
     }
 
+    @Override
+    public void removeEventPublisherConfigurations(int tenantId) {
+
+        Map<String, EventPublisher> eventPublisherMap = tenantSpecificEventPublisherConfigurationMap.remove(tenantId);
+        if (eventPublisherMap != null) {
+            for (EventPublisher eventPublisher : eventPublisherMap.values()) {
+                try {
+                    eventPublisher.prepareDestroy();
+                    EventPublisherServiceValueHolder.getEventStreamService().unsubscribe(eventPublisher);
+                    eventPublisher.destroy();
+                } catch (RuntimeException e) {
+                    log.warn("Error while destroying event publisher: "
+                            + eventPublisher.getEventPublisherConfiguration().getEventPublisherName()
+                            + " of tenant: " + tenantId, e);
+                }
+            }
+        }
+        tenantSpecificEventPublisherConfigurationFileMap.remove(tenantId);
+        tenantSpecificDeployerMap.remove(tenantId);
+        if (log.isDebugEnabled()) {
+            log.debug("Removed in-memory event publisher configurations of tenant: " + tenantId);
+        }
+    }
+
     public void removeEventPublisherConfigurationFile(String fileName, int tenantId) {
         List<EventPublisherConfigurationFile> eventPublisherConfigurationFileList = tenantSpecificEventPublisherConfigurationFileMap.get(tenantId);
         if (eventPublisherConfigurationFileList != null) {

--- a/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/EventStreamService.java
+++ b/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/EventStreamService.java
@@ -103,4 +103,16 @@ public interface EventStreamService {
             throws EventStreamConfigurationException {
     }
 
+    /**
+     * Removes every event stream configuration and event junction held in memory for the given tenant.
+     * Intended to be invoked when a tenant is unloaded — after its event publishers have been removed —
+     * so that per-tenant stream state does not accumulate for every tenant ever loaded during the
+     * server's lifetime.
+     *
+     * @param tenantId Tenant ID.
+     */
+    public default void removeEventStreamConfigurations(int tenantId) {
+
+    }
+
 }

--- a/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/CarbonEventStreamService.java
+++ b/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/CarbonEventStreamService.java
@@ -424,4 +424,14 @@ public class CarbonEventStreamService implements EventStreamService {
         }
         return true;
     }
+
+    @Override
+    public void removeEventStreamConfigurations(int tenantId) {
+
+        tenantSpecificEventStreamConfigs.remove(tenantId);
+        EventStreamServiceValueHolder.getEventStreamRuntime().removeEventJunctions(tenantId);
+        if (log.isDebugEnabled()) {
+            log.debug("Removed in-memory event stream configurations of tenant: " + tenantId);
+        }
+    }
 }

--- a/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/EventStreamRuntime.java
+++ b/components/event-stream/org.wso2.carbon.event.stream.core/src/main/java/org/wso2/carbon/event/stream/core/internal/EventStreamRuntime.java
@@ -38,6 +38,16 @@ public class EventStreamRuntime {
     private Map<Integer, Map<String, EventJunction>> tenantSpecificEventJunctions =
             new HashMap<Integer, Map<String, EventJunction>>();
 
+    /**
+     * Drops every event junction of the given tenant. Used on tenant unload so junctions (and the
+     * producer/consumer lists they hold) do not accumulate for every tenant ever loaded.
+     *
+     * @param tenantId Tenant ID.
+     */
+    public synchronized void removeEventJunctions(int tenantId) {
+        tenantSpecificEventJunctions.remove(tenantId);
+    }
+
     public void deleteStreamJunction(String streamId)
             throws EventStreamConfigurationException {
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();


### PR DESCRIPTION
## Problem

The per-tenant maps in `CarbonEventPublisherService` (`tenantSpecificEventPublisherConfigurationMap`, file/deployer maps), `CarbonOutputEventAdapterService` (`tenantSpecificEventAdapters`) and `CarbonEventStreamService` / `EventStreamRuntime` (`tenantSpecificEventStreamConfigs`, `tenantSpecificEventJunctions`) are populated when a tenant is loaded (via the tenant resource manager's `creatingConfigurationContext` observer) but are never cleaned when the tenant's configuration context is unloaded by idle eviction.

In large multi-tenant deployments this means publisher runtimes, output adapter instances and stream junctions accumulate for **every tenant ever loaded** since JVM start — with N publishers per tenant this grows to hundreds of MB / GBs of retained heap that is dead weight for idle tenants and is only released on restart.

## Changes

- `EventPublisherService#removeEventPublisherConfigurations(int tenantId)` (default method, implemented in `CarbonEventPublisherService`): destroys each of the tenant's `EventPublisher` runtimes — releasing the output adapter instance via the existing `destroy()` path and unsubscribing from the stream junction — and removes the tenant's entries from the publisher, file and deployer maps.
- `EventStreamService#removeEventStreamConfigurations(int tenantId)` (default method, implemented in `CarbonEventStreamService`): removes the tenant's stream configurations and drops its event junctions (`EventStreamRuntime#removeEventJunctions`).

Both must be invoked within the tenant's carbon context flow and are intended to be called from a tenant-unload observer (`terminatingConfigurationContext`) — a follow-up PR to identity-governance's tenant resource manager wires this up. The runtimes are re-created by the existing tenant-load path the next time the tenant is accessed, so in-memory eventing state becomes proportional to the currently-loaded tenant set instead of every tenant ever loaded.